### PR TITLE
Update dependencies and fix compiler warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,12 @@ description = "URDF parser using serde-xml-rs"
 license = "Apache-2.0"
 keywords = ["robotics", "robot", "ros", "urdf"]
 categories = ["data-structures", "parsing"]
-repository = "https://github.com/OTL/urdf-rs"
+repository = "https://github.com/openrr/urdf-rs"
 documentation = "http://docs.rs/urdf-rs"
 
 [dependencies]
-serde-xml-rs = "0.3.1"
-serde = "1.0.89"
-serde_derive = "1.0.89"
-RustyXML = "0.1.1"
-regex = "1.1.2"
+serde-xml-rs = "0.4.0"
+serde = "1.0.118"
+serde_derive = "1.0.118"
+RustyXML = "0.3.0"
+regex = "1.4.2"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# urdf-rs [![Build Status](https://travis-ci.org/OTL/urdf-rs.svg?branch=master)](https://travis-ci.org/OTL/urdf-rs)  [![crates.io](https://img.shields.io/crates/v/urdf-rs.svg)](https://crates.io/crates/urdf-rs)
-
+# urdf-rs [![Build Status](https://travis-ci.org/openrr/urdf-rs.svg?branch=master)](https://travis-ci.org/openrr/urdf-rs)  [![crates.io](https://img.shields.io/crates/v/urdf-rs.svg)](https://crates.io/crates/urdf-rs)
 
 [URDF](http://wiki.ros.org/urdf) parser using [serde-xml-rs](https://github.com/RReverser/serde-xml-rs) for rust.
 

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -38,14 +38,6 @@ pub enum Geometry {
     },
 }
 
-fn default_scale() -> [f64; 3] {
-    [1.0f64; 3]
-}
-
-fn default_one() -> f64 {
-    1.0f64
-}
-
 impl Default for Geometry {
     fn default() -> Geometry {
         Geometry::Box { size: [0.0f64, 0.0, 0.0] }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,8 @@
-use std::error::Error;
+use serde_xml_rs;
 use std;
+use std::error::Error;
 use std::fmt;
 use std::string;
-use serde_xml_rs;
 use xml;
 
 #[derive(Debug)]
@@ -28,17 +28,7 @@ impl fmt::Display for UrdfError {
     }
 }
 
-impl Error for UrdfError {
-    fn description(&self) -> &str {
-        match *self {
-            UrdfError::File(ref err) => err.description(),
-            UrdfError::Xml(ref err) => err.description(),
-            UrdfError::RustyXml(ref err) => err.description(),
-            UrdfError::Parse(ref err) => &err,
-            UrdfError::Command(ref err) => &err,
-        }
-    }
-}
+impl Error for UrdfError {}
 
 impl From<std::io::Error> for UrdfError {
     fn from(err: std::io::Error) -> UrdfError {
@@ -66,6 +56,6 @@ impl<'a> From<&'a str> for UrdfError {
 
 impl From<string::FromUtf8Error> for UrdfError {
     fn from(err: string::FromUtf8Error) -> UrdfError {
-        UrdfError::Command(err.description().to_owned())
+        UrdfError::Command(err.to_string())
     }
 }

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -3,9 +3,7 @@ use errors::*;
 
 use serde_xml_rs;
 use std::path::Path;
-use std::io::prelude::*;
 use xml;
-use std::fs::File;
 
 /// sort <link> and <joint> to avoid the [issue](https://github.com/RReverser/serde-xml-rs/issues/5)
 fn sort_link_joint(string: &str) -> Result<String> {
@@ -42,12 +40,8 @@ fn sort_link_joint(string: &str) -> Result<String> {
 /// println!("{:?}", links[0].visual[0].origin.xyz);
 /// ```
 pub fn read_file<P: AsRef<Path>>(path: P) -> Result<Robot> {
-    let mut file = File::open(path)?;
-    let mut contents = String::new();
-    file.read_to_string(&mut contents)?;
-    read_from_string(&contents)
+    read_from_string(&std::fs::read_to_string(path)?)
 }
-
 
 /// Read from string instead of file.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! # urdf-rs
 //!
-//! [![Build Status](https://travis-ci.org/OTL/urdf-rs.svg?branch=master)]
-//! (https://travis-ci.org/OTL/urdf-rs)
+//! [![Build Status](https://travis-ci.org/openrr/urdf-rs.svg?branch=master)]
+//! (https://travis-ci.org/openrr/urdf-rs)
 //!
 //! [URDF](http://wiki.ros.org/urdf) parser using
 //! [serde-xml-rs](https://github.com/RReverser/serde-xml-rs) for rust.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -75,7 +75,7 @@ where
 {
     if let Some(ext) = input_path.as_ref().extension() {
         if ext == "xacro" {
-            let urdf_utf = try!(convert_xacro_to_urdf(input_path.as_ref()));
+            let urdf_utf = convert_xacro_to_urdf(input_path.as_ref())?;
             read_from_string(&urdf_utf)
         } else {
             read_file(&input_path)


### PR DESCRIPTION
- Fix various links such as Travis CI build badge and cargo repository
link.
- The use of `try!` macro is deprecated in favor of `?`. Occurences were
replaced.
- The functions `default_scale()` and `default_one()` were never used, they were
deleted.
- Use of `Error::description` is deprecated in favor of `Display` or
`to_string`. Implementation of `Error::description` was deleted, as
`impl Display for UrdfError` already existed.
- Used `std::fs::read_to_string` instead of custom implementation