### PR TITLE
Reduce public dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,10 @@ categories = ["data-structures", "parsing"]
 repository = "https://github.com/openrr/urdf-rs"
 documentation = "http://docs.rs/urdf-rs"
 
+# Note: serde is public dependency.
 [dependencies]
-serde-xml-rs = "0.4.0"
-serde = { version = "1.0.118", features = ["derive"] }
-RustyXML = "0.3.0"
 regex = "1.4.2"
+RustyXML = "0.3.0"
+serde = { version = "1.0.118", features = ["derive"] }
+serde-xml-rs = "0.4.0"
+thiserror = "1.0.7"

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 /// sort <link> and <joint> to avoid the [issue](https://github.com/RReverser/serde-xml-rs/issues/5)
 fn sort_link_joint(string: &str) -> Result<String> {
-    let e: xml::Element = string.parse()?;
+    let e: xml::Element = string.parse().map_err(UrdfError::new)?;
     let mut links = Vec::new();
     let mut joints = Vec::new();
     let mut materials = Vec::new();
@@ -94,7 +94,7 @@ pub fn read_file<P: AsRef<Path>>(path: P) -> Result<Robot> {
 
 pub fn read_from_string(string: &str) -> Result<Robot> {
     let sorted_string = sort_link_joint(string)?;
-    serde_xml_rs::from_str(&sorted_string).map_err(From::from)
+    serde_xml_rs::from_str(&sorted_string).map_err(UrdfError::new)
 }
 
 #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,7 +25,7 @@ where
     if output.status.success() {
         Ok(String::from_utf8(output.stdout)?)
     } else {
-        Err(UrdfError::Command("faild to xacro".to_owned()))
+        Err(ErrorKind::Command("faild to xacro".to_owned()).into())
     }
 }
 
@@ -73,7 +73,7 @@ where
             read_file(&input_path)
         }
     } else {
-        return Err(UrdfError::Command("failed to get extension".to_owned()));
+        Err(ErrorKind::Command("failed to get extension".to_owned()).into())
     }
 }
 


### PR DESCRIPTION
Hiding error variants from a library's public error type to prevent dependency updates from becoming breaking changes.
We can add `UrdfErrorKind` enum or `is_*` methods that indicate the kind of error if needed, but don't expose dependencies' types directly in the public API.

This reduces public dependencies from 3 (`serde`, `serde-xml-rs`, `RustyXML`) to 1 (`serde`).

Refs: https://github.com/dtolnay/thiserror/pull/50