### PR TITLE
Fix format check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install Rust
       run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
-    - run: cargo fmt
-      if: matrix.target == 'stable'
+    - run: cargo fmt -- --check
+      if: matrix.rust == 'stable'
     - run: cargo build --verbose
     - run: cargo test --verbose


### PR DESCRIPTION
https://github.com/openrr/urdf-rs/pull/10#discussion_r566001872

> rustfmt will not return an error even if there is code that needs to be formatted unless we pass a `--check` flag.
> And since there is no matrix named `target`, `matrix.target == 'stable'` is always false.