### PR TITLE
Minor performance improvements

### DIFF
--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -136,9 +136,7 @@ mod urdf_vec3 {
             )));
         }
         let mut arr = [0.0f64; 3];
-        for i in 0..3 {
-            arr[i] = vec[i];
-        }
+        arr.copy_from_slice(&vec);
         Ok(arr)
     }
 }
@@ -187,9 +185,7 @@ mod urdf_vec4 {
             )));
         }
         let mut arr = [0.0f64; 4];
-        for i in 0..4 {
-            arr[i] = vec[i];
-        }
+        arr.copy_from_slice(&vec);
         Ok(arr)
     }
 }

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -20,7 +20,7 @@ fn sort_link_joint(string: &str) -> Result<String> {
             }
         };
     }
-    let mut new_elm = e.clone();
+    let mut new_elm = e;
     links.extend(joints);
     links.extend(materials);
     new_elm.children = links;


### PR DESCRIPTION
- ~~Reduce allocation in deserialize functions~~ EDIT: see https://github.com/openrr/urdf-rs/pull/14#issuecomment-772233997
- Use copy_from_slice instead of for-loops, see https://rust-lang.github.io/rust-clippy/stable/index.html#manual_memcpy for details
- Remove needless clone