### PR TITLE
Do not compile regular expression per function call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "http://docs.rs/urdf-rs"
 
 # Note: serde is public dependency.
 [dependencies]
+once_cell = "1"
 regex = "1.4.2"
 RustyXML = "0.3.0"
 serde = { version = "1.0.118", features = ["derive"] }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,7 @@ use crate::deserialize::Robot;
 use crate::errors::*;
 use crate::funcs::*;
 
+use once_cell::sync::Lazy;
 use regex::Regex;
 use std::path::Path;
 use std::process::Command;
@@ -45,9 +46,10 @@ pub fn rospack_find(package: &str) -> Option<String> {
 }
 
 pub fn expand_package_path(filename: &str, base_dir: Option<&Path>) -> String {
+    static RE: Lazy<Regex> = Lazy::new(|| Regex::new("^package://(\\w+)/").unwrap());
+
     if filename.starts_with("package://") {
-        let re = Regex::new("^package://(\\w+)/").unwrap();
-        re.replace(filename, |ma: &regex::Captures| {
+        RE.replace(filename, |ma: &regex::Captures| {
             match rospack_find(&ma[1]) {
                 Some(found_path) => found_path + "/",
                 None => panic!("failed to find ros package {}", &ma[1]),


### PR DESCRIPTION
Currently, expand_package_path compiles regular expression per it called. This is not very efficient.

Refs: https://github.com/rust-lang/regex/blob/master/PERFORMANCE.md#thou-shalt-not-compile-regular-expressions-in-a-loop