### PR TITLE
Release 0.6.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urdf-rs"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Takashi Ogura <t.ogura@gmail.com>"]
 edition = "2018"
 description = "URDF parser using serde-xml-rs"

--- a/LICENSE
+++ b/LICENSE
@@ -178,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# urdf-rs [![Build Status](https://img.shields.io/github/workflow/status/openrr/urdf-rs/CI/main)](https://github.com/openrr/urdf-rs/actions?query=workflow%3ACI+branch%3Amain)  [![crates.io](https://img.shields.io/crates/v/urdf-rs.svg)](https://crates.io/crates/urdf-rs)
+# urdf-rs
+
+[![Build Status](https://img.shields.io/github/workflow/status/openrr/urdf-rs/CI/main)](https://github.com/openrr/urdf-rs/actions) [![crates.io](https://img.shields.io/crates/v/urdf-rs.svg)](https://crates.io/crates/urdf-rs) [![docs](https://docs.rs/urdf-rs/badge.svg)](https://docs.rs/urdf-rs)
 
 [URDF](http://wiki.ros.org/urdf) parser using [serde-xml-rs](https://github.com/RReverser/serde-xml-rs) for rust.
 
 Only [link](http://wiki.ros.org/urdf/XML/link) and [joint](http://wiki.ros.org/urdf/XML/joint) are supported.
-
-[Documentation](https://docs.rs/urdf-rs/)
 
 ## Example
 
@@ -20,7 +20,8 @@ println!("{:?}", joints[0].origin.xyz);
 
 ## Contributors
 
-* Johan Andersson
-* Tom Olsson
-* Nate Kent
-* Wout Schellaert
+<a href="https://github.com/openrr/urdf-rs/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=openrr/urdf-rs" />
+</a>
+
+Made with [contrib.rocks](https://contrib.rocks).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can access urdf elements like below example.
 ```rust
 let urdf_robo = urdf_rs::read_file("sample.urdf").unwrap();
 let links = urdf_robo.links;
-println!("{:?}", links[0].visual.origin.xyz);
+println!("{:?}", links[0].visual[0].origin.xyz);
 let joints = urdf_robo.joints;
 println!("{:?}", joints[0].origin.xyz);
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,25 +1,4 @@
-//! # urdf-rs
-//!
-//! [![Build Status](https://img.shields.io/github/workflow/status/openrr/urdf-rs/CI/main)](https://github.com/openrr/urdf-rs/actions?query=workflow%3ACI+branch%3Amain)
-//!
-//! [URDF](http://wiki.ros.org/urdf) parser using
-//! [serde-xml-rs](https://github.com/RReverser/serde-xml-rs) for rust.
-//!
-//! Only [link](http://wiki.ros.org/urdf/XML/link) and
-//! [joint](http://wiki.ros.org/urdf/XML/joint) are supported.
-//!
-//! # Examples
-//!
-//! You can access urdf elements like below example.
-//!
-//! ```
-//! let urdf_robo = urdf_rs::read_file("sample.urdf").unwrap();
-//! let links = urdf_robo.links;
-//! println!("{:?}", links[0].visual[0].origin.xyz);
-//! let joints = urdf_robo.joints;
-//! println!("{:?}", joints[0].origin.xyz);
-//! ```
-
+#![doc = include_str!("../README.md")]
 #![warn(missing_debug_implementations, rust_2018_idioms)]
 
 mod errors;


### PR DESCRIPTION
Changes:
- Update serde-xml-rs to 0.5 (#26)
- Performance improvement (#18)

This PR also includes the following (see the first, second, and third commits for more):

- Use docs.rs badge instead of doc link (369d43ad45488400da741d5cb446999e80ffc58a)
- Replace manually maintained contributor list with contributors image by contrib.rocks (369d43ad45488400da741d5cb446999e80ffc58a) [\[rendered\]](https://github.com/openrr/urdf-rs/tree/d78c210503ef73b78574f155b02fc0430ec56fe7#contributors)
- Use readme as crate-level docs (369d43ad45488400da741d5cb446999e80ffc58a)
- Update license text to match original (b4445320234bcd80107bec3ce1401d5e8abbac4d)
- Fix compile error in example in readme (27fff2186f26659cad81f6c9a60cde2e5f1ee79f)