### PR TITLE
Fall back to xacro binary in case rosrun doesn't exists

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,6 +15,7 @@ where
         .args(&["xacro", "xacro", "--inorder"])
         .arg(filename.as_ref())
         .output()
+        .or_else(|_| Command::new("xacro").arg(filename.as_ref()).output())
         .expect("failed to execute xacro. install by apt-get install ros-*-xacro");
     if output.status.success() {
         Ok(String::from_utf8(output.stdout)?)


### PR DESCRIPTION
Thanks for the awesome libraries!

When sourcing `/opt/ros/.../setup.bash` it update the `PATH` environment variable to have `/opt/ros/.../bin` which contains the `xacro` binary, this is needed to make urdf-viz work with ROS2.

Another solution would be to always use `xacro` since the path to the binary directory will be set for ROS1, too, which mean we could use `xacro` directly for both versions.
