### PR TITLE
Fix newly added clippy warning

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,7 +12,7 @@ where
     P: AsRef<Path>,
 {
     let output = Command::new("rosrun")
-        .args(&["xacro", "xacro", "--inorder"])
+        .args(["xacro", "xacro", "--inorder"])
         .arg(filename.as_ref())
         .output()
         .or_else(|_| Command::new("xacro").arg(filename.as_ref()).output())
@@ -37,7 +37,7 @@ pub fn rospack_find(package: &str) -> Option<String> {
         // support ROS2
         .or_else(|_| {
             Command::new("ros2")
-                .args(&["pkg", "prefix", "--share"])
+                .args(["pkg", "prefix", "--share"])
                 .arg(package)
                 .output()
         })


### PR DESCRIPTION
```
warning: the borrowed expression implements the required traits
  --> src/utils.rs:15:15
   |
15 |         .args(&["xacro", "xacro", "--inorder"])
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `["xacro", "xacro", "--inorder"]`
   |
   = note: `#[warn(clippy::needless_borrow)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
  --> src/utils.rs:40:23
   |
40 |                 .args(&["pkg", "prefix", "--share"])
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `["pkg", "prefix", "--share"]`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```