### PR TITLE
Add ignored inertial data to sorted link data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urdf-rs"
-version = "0.6.7"
+version = "0.6.8"
 authors = ["Takashi Ogura <t.ogura@gmail.com>"]
 edition = "2021"
 description = "URDF parser using serde-xml-rs"

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -32,7 +32,7 @@ fn sort_visual_collision(elm: &xml::Element) -> xml::Xml {
     let mut collisions = Vec::new();
     for c in &elm.children {
         if let xml::Xml::ElementNode(xml_elm) = c {
-            if xml_elm.name == "visual" {
+            if xml_elm.name == "visual" || xml_elm.name == "inertial" {
                 visuals.push(xml::Xml::ElementNode(xml_elm.clone()));
             } else if xml_elm.name == "collision" {
                 collisions.push(xml::Xml::ElementNode(xml_elm.clone()));
@@ -183,6 +183,7 @@ fn it_works() {
     assert_eq!(robot.links.len(), 3);
     assert_eq!(robot.joints.len(), 2);
     assert_eq!(robot.links[0].visual.len(), 3);
+    assert_eq!(robot.links[0].inertial.mass.value, 1.0);
     let xyz = robot.links[0].visual[0].origin.xyz;
     assert_approx_eq!(xyz[0], 0.1);
     assert_approx_eq!(xyz[1], 0.2);


### PR DESCRIPTION
This addresses #56 that causes the inertial data to always pull from the default value. 
- Added a condition to also consider inertial fields when looking for children of the link
- Added a condition to test for accurate parsing of inertial data