### PR TITLE
Migrate to yaserde and add support for urdf serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["robotics", "robot", "ros", "urdf"]
 categories = ["data-structures", "parsing"]
 repository = "https://github.com/openrr/urdf-rs"
 
-# Note: serde is public dependency.
+# Note: yaserde is public dependency.
 [dependencies]
 once_cell = "1"
 regex = "1.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/openrr/urdf-rs"
 [dependencies]
 once_cell = "1"
 regex = "1.4.2"
-RustyXML = "0.3.0"
 yaserde = "0.7.0"
 yaserde_derive = "0.7.0"
 thiserror = "1.0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,8 @@ repository = "https://github.com/openrr/urdf-rs"
 once_cell = "1"
 regex = "1.4.2"
 RustyXML = "0.3.0"
-serde = { version = "1.0.118", features = ["derive"] }
 yaserde = "0.7.0"
 yaserde_derive = "0.7.0"
-serde-xml-rs = "0.6.0"
 thiserror = "1.0.7"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ once_cell = "1"
 regex = "1.4.2"
 RustyXML = "0.3.0"
 serde = { version = "1.0.118", features = ["derive"] }
+yaserde = "0.7.0"
+yaserde_derive = "0.7.0"
 serde-xml-rs = "0.6.0"
 thiserror = "1.0.7"
 

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -38,8 +38,6 @@ pub struct Inertial {
     pub inertia: Inertia,
 }
 
-// TODO(anyone) Derive YaSerialize and YaSerialize and remove custom impl once upstream bug is fixed
-// https://github.com/media-io/yaserde/issues/129
 #[derive(Debug, Clone)]
 pub enum Geometry {
     Box {
@@ -70,6 +68,8 @@ impl Default for Geometry {
     }
 }
 
+// TODO(anyone) Derive YaSerialize and YaSerialize and remove custom impl once upstream bug is fixed
+// https://github.com/media-io/yaserde/issues/129
 impl YaSerialize for Geometry {
     fn serialize<W: Write>(
         &self,
@@ -147,6 +147,25 @@ impl YaSerialize for Geometry {
     }
 }
 
+impl Vec3 {
+    fn from_string(v: &String) -> Result<Self, String> {
+        let split_results: Vec<_> = v
+            .split_whitespace()
+            .filter_map(|s| s.parse::<f64>().ok())
+            .collect();
+        if split_results.len() != 3 {
+            return Err(format!(
+                "Wrong vector element count, expected 3 found {} for [{}]",
+                split_results.len(),
+                v
+            ));
+        }
+        let mut res = [0.0f64; 3];
+        res.copy_from_slice(&split_results);
+        Ok(Vec3(res))
+    }
+}
+
 impl YaDeserialize for Geometry {
     fn deserialize<R: Read>(
         deserializer: &mut yaserde::de::Deserializer<R>,
@@ -164,20 +183,9 @@ impl YaDeserialize for Geometry {
                 .collect();
             if name.local_name == "box" {
                 if let Some(v) = attributes.get("size") {
-                    let split_results: Vec<_> = v
-                        .split_whitespace()
-                        .filter_map(|s| s.parse::<f64>().ok())
-                        .collect();
-                    if split_results.len() != 3 {
-                        return Err(format!(
-                            "Wrong vector element count, expected 3 found {} for [{}]",
-                            split_results.len(),
-                            v
-                        ));
-                    }
-                    let mut res = [0.0f64; 3];
-                    res.copy_from_slice(&split_results);
-                    Ok(Self::Box { size: Vec3(res) })
+                    Ok(Self::Box {
+                        size: Vec3::from_string(v)?,
+                    })
                 } else {
                     Err(format!(
                         "Failed parsing attributes for box {:?}",
@@ -213,25 +221,9 @@ impl YaDeserialize for Geometry {
                     .get("filename")
                     .and_then(|a| a.parse::<String>().ok())
                 {
-                    let scale = if let Some(v) = attributes.get("scale") {
-                        // TODO(luca) remove duplication with all vec parsing code
-                        let split_results: Vec<_> = v
-                            .split_whitespace()
-                            .filter_map(|s| s.parse::<f64>().ok())
-                            .collect();
-                        if split_results.len() != 3 {
-                            return Err(format!(
-                                "Wrong vector element count, expected 3 found {} for [{}]",
-                                split_results.len(),
-                                v
-                            ));
-                        }
-                        let mut res = [0.0f64; 3];
-                        res.copy_from_slice(&split_results);
-                        Some(Vec3(res))
-                    } else {
-                        None
-                    };
+                    let scale = attributes
+                        .get("scale")
+                        .and_then(|s| Vec3::from_string(s).ok());
                     Ok(Self::Mesh { filename, scale })
                 } else {
                     Err("Error parsing filename for mesh".to_string())
@@ -268,7 +260,6 @@ pub struct Material {
 
 #[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Visual {
-    // TODO(luca) check if name is actually implemented
     #[yaserde(attribute)]
     pub name: Option<String>,
     pub origin: Pose,
@@ -340,20 +331,7 @@ impl YaDeserialize for Vec3 {
     ) -> Result<Self, String> {
         deserializer.next_event()?;
         if let Ok(xml::reader::XmlEvent::Characters(v)) = deserializer.peek() {
-            let split_results: Vec<_> = v
-                .split_whitespace()
-                .filter_map(|s| s.parse::<f64>().ok())
-                .collect();
-            if split_results.len() != 3 {
-                return Err(format!(
-                    "Wrong vector element count, expected 3 found {} for [{}]",
-                    split_results.len(),
-                    v
-                ));
-            }
-            let mut res = [0.0f64; 3];
-            res.copy_from_slice(&split_results);
-            Ok(Vec3(res))
+            Ok(Vec3::from_string(v)?)
         } else {
             Err("String of elements not found while parsing Vec3".to_string())
         }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -325,15 +325,21 @@ pub struct LinkName {
 }
 
 #[derive(Debug, Default, YaDeserialize, YaSerialize, Clone, PartialEq, Eq)]
-#[yaserde(rename_all = "snake_case")]
 pub enum JointType {
+    #[yaserde(rename = "revolute")]
     Revolute,
+    #[yaserde(rename = "continuous")]
     Continuous,
+    #[yaserde(rename = "prismatic")]
     Prismatic,
     #[default]
+    #[yaserde(rename = "fixed")]
     Fixed,
+    #[yaserde(rename = "floating")]
     Floating,
+    #[yaserde(rename = "planar")]
     Planar,
+    #[yaserde(rename = "spherical")]
     Spherical,
 }
 
@@ -366,7 +372,7 @@ pub struct SafetyController {
 pub struct Joint {
     #[yaserde(attribute)]
     pub name: String,
-    #[yaserde(rename = "type")]
+    #[yaserde(attribute, rename = "type")]
     pub joint_type: JointType,
     pub origin: Pose,
     pub parent: LinkName,

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -398,7 +398,7 @@ impl YaDeserialize for Vec4 {
             res.copy_from_slice(&split_results);
             Ok(Vec4(res))
         } else {
-            Err("String of elements not found while parsing Vec3".to_string())
+            Err("String of elements not found while parsing Vec4".to_string())
         }
     }
 }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,11 +1,14 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use serde::de::{Visitor};
 
-#[derive(Debug, Deserialize, Default, Clone)]
+use std::ops::{Deref, DerefMut};
+
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Mass {
     pub value: f64,
 }
 
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Inertia {
     pub ixx: f64,
     pub ixy: f64,
@@ -15,7 +18,7 @@ pub struct Inertia {
     pub izz: f64,
 }
 
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Inertial {
     #[serde(default)]
     pub origin: Pose,
@@ -23,12 +26,11 @@ pub struct Inertial {
     pub inertia: Inertia,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum Geometry {
     Box {
-        #[serde(with = "urdf_vec3")]
-        size: [f64; 3],
+        size: Vec3,
     },
     Cylinder {
         radius: f64,
@@ -43,46 +45,37 @@ pub enum Geometry {
     },
     Mesh {
         filename: String,
-        #[serde(with = "urdf_option_vec3", default)]
-        scale: Option<[f64; 3]>,
+        #[serde(default)]
+        scale: Option<Vec3>,
     },
 }
 
 impl Default for Geometry {
     fn default() -> Geometry {
         Geometry::Box {
-            size: [0.0f64, 0.0, 0.0],
+            size: Vec3::default(),
         }
     }
 }
 
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Color {
-    #[serde(with = "urdf_vec4")]
-    pub rgba: [f64; 4],
+    pub rgba: Vec4,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Texture {
     pub filename: String,
 }
 
-impl Default for Texture {
-    fn default() -> Texture {
-        Texture {
-            filename: "".to_string(),
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Material {
     pub name: String,
     pub color: Option<Color>,
     pub texture: Option<Texture>,
 }
 
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Visual {
     pub name: Option<String>,
     #[serde(default)]
@@ -91,7 +84,7 @@ pub struct Visual {
     pub material: Option<Material>,
 }
 
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Collision {
     pub name: Option<String>,
     #[serde(default)]
@@ -101,7 +94,7 @@ pub struct Collision {
 
 /// Urdf Link element
 /// See <http://wiki.ros.org/urdf/XML/link> for more detail.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Link {
     pub name: String,
     #[serde(default)]
@@ -112,124 +105,145 @@ pub struct Link {
     pub collision: Vec<Collision>,
 }
 
-#[derive(Deserialize, Debug, Clone)]
-pub struct Vec3 {
-    #[serde(with = "urdf_vec3")]
-    pub data: [f64; 3],
-}
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct Vec3([f64; 3]);
 
-mod urdf_vec3 {
-    use serde::{self, Deserialize, Deserializer};
-    pub fn deserialize<'a, D>(deserializer: D) -> Result<[f64; 3], D::Error>
-    where
-        D: Deserializer<'a>,
-    {
-        let s = String::deserialize(deserializer)?;
-        let vec = s
-            .split(' ')
-            .filter_map(|x| x.parse::<f64>().ok())
-            .collect::<Vec<_>>();
-        if vec.len() != 3 {
-            return Err(serde::de::Error::custom(format!(
-                "failed to parse float array in {s}"
-            )));
-        }
-        let mut arr = [0.0f64; 3];
-        arr.copy_from_slice(&vec);
-        Ok(arr)
+impl Deref for Vec3 {
+    type Target = [f64; 3];
+
+    fn deref(&self) -> &Self::Target {
+        return &self.0;
     }
 }
 
-mod urdf_option_vec3 {
-    use serde::{self, Deserialize, Deserializer};
-    pub fn deserialize<'a, D>(deserializer: D) -> Result<Option<[f64; 3]>, D::Error>
-    where
-        D: Deserializer<'a>,
-    {
-        let s = String::deserialize(deserializer)?;
-        let vec = s
-            .split(' ')
-            .filter_map(|x| x.parse::<f64>().ok())
-            .collect::<Vec<_>>();
-        if vec.is_empty() {
-            Ok(None)
-        } else if vec.len() == 3 {
-            let mut arr = [0.0; 3];
-            arr.copy_from_slice(&vec);
-            Ok(Some(arr))
-        } else {
-            Err(serde::de::Error::custom(format!(
-                "failed to parse float array in {s}"
-            )))
-        }
+impl DerefMut for Vec3 {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        return &mut self.0;
     }
 }
 
-mod urdf_vec4 {
-    use serde::{self, Deserialize, Deserializer};
-    pub fn deserialize<'a, D>(deserializer: D) -> Result<[f64; 4], D::Error>
+impl Serialize for Vec3 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        D: Deserializer<'a>,
+        S: serde::Serializer,
     {
-        let s = String::deserialize(deserializer)?;
-        let vec = s
-            .split(' ')
-            .filter_map(|x| x.parse::<f64>().ok())
-            .collect::<Vec<_>>();
-        if vec.len() != 4 {
-            return Err(serde::de::Error::custom(format!(
-                "failed to parse float array in {s}"
-            )));
-        }
-        let mut arr = [0.0f64; 4];
-        arr.copy_from_slice(&vec);
-        Ok(arr)
+        serializer.serialize_str(&format!("{} {} {}", self.0[0], self.0[1], self.0[2]))
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+impl<'de> Deserialize<'de> for Vec3 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(Vec3Visitor)
+    }
+}
+
+struct Vec3Visitor;
+impl<'de> Visitor<'de> for Vec3Visitor {
+    type Value = Vec3;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(
+            "a string containing three floating point values separated by spaces",
+        )
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        let split_results: Vec<_> = v.split_whitespace().filter_map(|s| s.parse::<f64>().ok()).collect();
+        if split_results.len() != 3 {
+            return Err(E::custom(format!(
+                "Wrong vector element count, expected 3 found {} for [{}]", split_results.len(), v)));
+        }
+        let mut res = [0.0f64; 3];
+        res.copy_from_slice(&split_results);
+        return Ok(Vec3(res));
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct Vec4([f64; 4]);
+
+impl Deref for Vec4 {
+    type Target = [f64; 4];
+
+    fn deref(&self) -> &Self::Target {
+        return &self.0;
+    }
+}
+
+impl DerefMut for Vec4 {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        return &mut self.0;
+    }
+}
+
+impl Serialize for Vec4 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!("{} {} {} {}", self.0[0], self.0[1], self.0[2], self.0[3]))
+    }
+}
+
+impl<'de> Deserialize<'de> for Vec4 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(Vec4Visitor)
+    }
+}
+
+struct Vec4Visitor;
+impl<'de> Visitor<'de> for Vec4Visitor {
+    type Value = Vec4;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(
+            "a string containing four floating point values separated by spaces",
+        )
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        let split_results: Vec<_> = v.split_whitespace().filter_map(|s| s.parse::<f64>().ok()).collect();
+        if split_results.len() != 4 {
+            return Err(E::custom(format!(
+                "Wrong vector element count, expected 4 found {} for [{}]", split_results.len(), v)));
+        }
+        let mut res = [0.0f64; 4];
+        res.copy_from_slice(&split_results);
+        return Ok(Vec4(res));
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Axis {
-    #[serde(with = "urdf_vec3")]
-    pub xyz: [f64; 3],
+    pub xyz: Vec3,
 }
 
-impl Default for Axis {
-    fn default() -> Axis {
-        Axis {
-            xyz: [1.0f64, 0.0, 0.0],
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct Pose {
-    #[serde(with = "urdf_vec3")]
-    #[serde(default = "default_zero3")]
-    pub xyz: [f64; 3],
-    #[serde(with = "urdf_vec3")]
-    #[serde(default = "default_zero3")]
-    pub rpy: [f64; 3],
+    #[serde(default)]
+    pub xyz: Vec3,
+    #[serde(default)]
+    pub rpy: Vec3,
 }
 
-fn default_zero3() -> [f64; 3] {
-    [0.0f64, 0.0, 0.0]
-}
-
-impl Default for Pose {
-    fn default() -> Pose {
-        Pose {
-            xyz: default_zero3(),
-            rpy: default_zero3(),
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct LinkName {
     pub link: String,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum JointType {
     Revolute,
@@ -241,7 +255,7 @@ pub enum JointType {
     Spherical,
 }
 
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct JointLimit {
     #[serde(default)]
     pub lower: f64,
@@ -251,14 +265,14 @@ pub struct JointLimit {
     pub velocity: f64,
 }
 
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Mimic {
     pub joint: String,
     pub multiplier: Option<f64>,
     pub offset: Option<f64>,
 }
 
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct SafetyController {
     #[serde(default)]
     pub soft_lower_limit: f64,
@@ -271,7 +285,7 @@ pub struct SafetyController {
 
 /// Urdf Joint element
 /// See <http://wiki.ros.org/urdf/XML/joint> for more detail.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Joint {
     pub name: String,
     #[serde(rename = "type")]
@@ -289,7 +303,7 @@ pub struct Joint {
     pub safety_controller: Option<SafetyController>,
 }
 
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Dynamics {
     #[serde(default)]
     pub damping: f64,
@@ -298,7 +312,7 @@ pub struct Dynamics {
 }
 
 /// Top level struct to access urdf.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Robot {
     #[serde(default)]
     pub name: String,

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,107 +1,172 @@
-use serde::de::Visitor;
-use serde::{Deserialize, Serialize};
+use yaserde::{YaSerialize, YaDeserialize, Visitor};
+use yaserde::xml::namespace::Namespace;
+use yaserde::ser::Serializer;
+use yaserde::xml::attribute::OwnedAttribute;
+use yaserde::xml;
+use yaserde_derive::{YaSerialize, YaDeserialize};
+
+use std::io::{Read, Write};
 
 use std::ops::{Deref, DerefMut};
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Mass {
+    #[yaserde(attribute)]
     pub value: f64,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Inertia {
+    #[yaserde(attribute)]
     pub ixx: f64,
+    #[yaserde(attribute)]
     pub ixy: f64,
+    #[yaserde(attribute)]
     pub ixz: f64,
+    #[yaserde(attribute)]
     pub iyy: f64,
+    #[yaserde(attribute)]
     pub iyz: f64,
+    #[yaserde(attribute)]
     pub izz: f64,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Inertial {
-    #[serde(default)]
     pub origin: Pose,
     pub mass: Mass,
     pub inertia: Inertia,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
-#[serde(rename_all = "snake_case")]
-pub enum Geometry {
-    Box {
-        size: Vec3,
-    },
-    Cylinder {
-        radius: f64,
-        length: f64,
-    },
-    Capsule {
-        radius: f64,
-        length: f64,
-    },
-    Sphere {
-        radius: f64,
-    },
-    Mesh {
-        filename: String,
-        #[serde(default)]
-        scale: Option<Vec3>,
-    },
+#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+pub struct BoxGeometry {
+    #[yaserde(attribute)]
+    pub size: Vec3,
 }
 
-impl Default for Geometry {
-    fn default() -> Geometry {
-        Geometry::Box {
-            size: Vec3::default(),
+#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+pub struct CylinderGeometry {
+    #[yaserde(attribute)]
+    pub radius: f64,
+    #[yaserde(attribute)]
+    pub length: f64,
+}
+
+#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+pub struct CapsuleGeometry {
+    #[yaserde(attribute)]
+    pub radius: f64,
+    #[yaserde(attribute)]
+    pub length: f64,
+}
+
+#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+pub struct SphereGeometry {
+    #[yaserde(attribute)]
+    pub radius: f64,
+}
+
+#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+pub struct MeshGeometry {
+    #[yaserde(attribute)]
+    pub filename: String,
+    #[yaserde(attribute)]
+    pub scale: Option<Vec3>,
+}
+
+pub enum Geometry {
+    Box(BoxGeometry),
+    Cylinder(CylinderGeometry),
+    Capsule(CapsuleGeometry),
+    Sphere(SphereGeometry),
+    Mesh(MeshGeometry),
+}
+
+#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+pub struct GeometrySerde {
+    #[yaserde(rename = "box")]
+    pub box_geometry: Option<BoxGeometry>,
+    #[yaserde(rename = "cylinder")]
+    pub cylinder: Option<CylinderGeometry>,
+    #[yaserde(rename = "capsule")]
+    pub capsule: Option<CapsuleGeometry>,
+    #[yaserde(rename = "sphere")]
+    pub sphere: Option<SphereGeometry>,
+    #[yaserde(rename = "mesh")]
+    pub mesh: Option<MeshGeometry>,
+}
+
+impl From<&GeometrySerde> for Geometry {
+    fn from(geom: &GeometrySerde) -> Geometry {
+        if let Some(b) = &geom.box_geometry {
+            Geometry::Box(b.clone())
+        } else if let Some(c) = &geom.cylinder {
+            Geometry::Cylinder(c.clone())
+        } else if let Some(c) = &geom.capsule {
+            Geometry::Capsule(c.clone())
+        } else if let Some(s) = &geom.sphere {
+            Geometry::Sphere(s.clone())
+        } else if let Some(m) = &geom.mesh {
+            Geometry::Mesh(m.clone())
+        } else {
+            panic!("Invalid geometry serde structure");
         }
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+impl Default for GeometrySerde {
+    fn default() -> Self {
+        Self {
+            box_geometry: Some(BoxGeometry{size: Vec3::default()}),
+            cylinder: None,
+            capsule: None,
+            sphere: None,
+            mesh: None,
+        }
+    }
+}
+
+#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Color {
     pub rgba: Vec4,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Texture {
     pub filename: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Material {
+    #[yaserde(attribute)]
     pub name: String,
     pub color: Option<Color>,
     pub texture: Option<Texture>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Visual {
     pub name: Option<String>,
-    #[serde(default)]
     pub origin: Pose,
-    pub geometry: Geometry,
+    pub geometry: GeometrySerde,
     pub material: Option<Material>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Collision {
     pub name: Option<String>,
-    #[serde(default)]
     pub origin: Pose,
-    pub geometry: Geometry,
+    pub geometry: GeometrySerde,
 }
 
 /// Urdf Link element
 /// See <http://wiki.ros.org/urdf/XML/link> for more detail.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
 pub struct Link {
+    #[yaserde(attribute)]
     pub name: String,
-    #[serde(default)]
     pub inertial: Inertial,
-    #[serde(default)]
     pub visual: Vec<Visual>,
-    #[serde(default)]
     pub collision: Vec<Collision>,
 }
 
@@ -122,50 +187,49 @@ impl DerefMut for Vec3 {
     }
 }
 
-impl Serialize for Vec3 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
+impl YaSerialize for Vec3 {
+    fn serialize<W: Write>(&self, serializer: &mut yaserde::ser::Serializer<W>) -> Result<(), String>
     {
-        serializer.serialize_str(&format!("{} {} {}", self.0[0], self.0[1], self.0[2]))
-    }
-}
-
-impl<'de> Deserialize<'de> for Vec3 {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_str(Vec3Visitor)
-    }
-}
-
-struct Vec3Visitor;
-impl<'de> Visitor<'de> for Vec3Visitor {
-    type Value = Vec3;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("a string containing three floating point values separated by spaces")
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        let split_results: Vec<_> = v
-            .split_whitespace()
-            .filter_map(|s| s.parse::<f64>().ok())
-            .collect();
-        if split_results.len() != 3 {
-            return Err(E::custom(format!(
-                "Wrong vector element count, expected 3 found {} for [{}]",
-                split_results.len(),
-                v
-            )));
+        // TODO(luca) cleanup this
+        println!("Serializing {:?}", self);
+        match serializer.write(xml::writer::XmlEvent::Characters(&format!("{} {} {}", self.0[0], self.0[1], self.0[2]))) {
+            Ok(()) => Ok(()),
+            Err(e) => Err(e.to_string()),
         }
-        let mut res = [0.0f64; 3];
-        res.copy_from_slice(&split_results);
-        return Ok(Vec3(res));
+    }
+
+    // TODO(luca) check this implementation
+    fn serialize_attributes(
+        &self, 
+        attributes: Vec<OwnedAttribute>, 
+        namespace: Namespace
+    ) -> Result<(Vec<OwnedAttribute>, Namespace), String> {
+        Ok((attributes, namespace))
+    }
+}
+
+impl YaDeserialize for Vec3 {
+    fn deserialize<R: Read>(deserializer: &mut yaserde::de::Deserializer<R>) -> Result<Self, String>
+    {
+        deserializer.next_event();
+        if let Ok(xml::reader::XmlEvent::Characters(v)) = deserializer.peek() {
+            let split_results: Vec<_> = v
+                .split_whitespace()
+                .filter_map(|s| s.parse::<f64>().ok())
+                .collect();
+            if split_results.len() != 3 {
+                return Err(format!(
+                    "Wrong vector element count, expected 3 found {} for [{}]",
+                    split_results.len(),
+                    v
+                ));
+            }
+            let mut res = [0.0f64; 3];
+            res.copy_from_slice(&split_results);
+            return Ok(Vec3(res));
+        } else {
+            return Err("String of elements not found while parsing Vec3".to_string());
+        }
     }
 }
 
@@ -186,154 +250,144 @@ impl DerefMut for Vec4 {
     }
 }
 
-impl Serialize for Vec4 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
+impl YaSerialize for Vec4 {
+    fn serialize<W: Write>(&self, serializer: &mut yaserde::ser::Serializer<W>) -> Result<(), String>
     {
-        serializer.serialize_str(&format!(
-            "{} {} {} {}",
-            self.0[0], self.0[1], self.0[2], self.0[3]
-        ))
-    }
-}
-
-impl<'de> Deserialize<'de> for Vec4 {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_str(Vec4Visitor)
-    }
-}
-
-struct Vec4Visitor;
-impl<'de> Visitor<'de> for Vec4Visitor {
-    type Value = Vec4;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("a string containing four floating point values separated by spaces")
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        let split_results: Vec<_> = v
-            .split_whitespace()
-            .filter_map(|s| s.parse::<f64>().ok())
-            .collect();
-        if split_results.len() != 4 {
-            return Err(E::custom(format!(
-                "Wrong vector element count, expected 4 found {} for [{}]",
-                split_results.len(),
-                v
-            )));
+        // TODO(luca) cleanup this
+        match serializer.write(xml::writer::XmlEvent::Characters(&format!("{} {} {} {}", self.0[0], self.0[1], self.0[2], self.0[3]))) {
+            Ok(()) => Ok(()),
+            Err(e) => Err(e.to_string()),
         }
-        let mut res = [0.0f64; 4];
-        res.copy_from_slice(&split_results);
-        return Ok(Vec4(res));
+    }
+
+    // TODO(luca) check this implementation
+    fn serialize_attributes(
+        &self, 
+        attributes: Vec<OwnedAttribute>, 
+        namespace: Namespace
+    ) -> Result<(Vec<OwnedAttribute>, Namespace), String> {
+        Ok((attributes, namespace))
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+impl YaDeserialize for Vec4 {
+    fn deserialize<R: Read>(deserializer: &mut yaserde::de::Deserializer<R>) -> Result<Self, String>
+    {
+        deserializer.next_event();
+        if let xml::reader::XmlEvent::Characters(v) = deserializer.peek()? {
+            let split_results: Vec<_> = v
+                .split_whitespace()
+                .filter_map(|s| s.parse::<f64>().ok())
+                .collect();
+            if split_results.len() != 4 {
+                return Err(format!(
+                    "Wrong vector element count, expected 4 found {} for [{}]",
+                    split_results.len(),
+                    v
+                ));
+            }
+            let mut res = [0.0f64; 4];
+            res.copy_from_slice(&split_results);
+            return Ok(Vec4(res));
+        } else {
+            return Err("String of elements not found while parsing Vec3".to_string());
+        }
+    }
+}
+
+#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Axis {
+    #[yaserde(attribute)]
     pub xyz: Vec3,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, YaDeserialize, YaSerialize, Clone)]
 pub struct Pose {
-    #[serde(default)]
+    #[yaserde(attribute)]
     pub xyz: Vec3,
-    #[serde(default)]
+    #[yaserde(attribute)]
     pub rpy: Vec3,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, YaDeserialize, YaSerialize, Clone)]
 pub struct LinkName {
+    #[yaserde(attribute)]
     pub link: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
+// TODO(luca) see if we can avoid deriving default
+#[derive(Debug, Default, YaDeserialize, YaSerialize, Clone, PartialEq, Eq)]
+#[yaserde(rename_all = "snake_case")]
 pub enum JointType {
     Revolute,
     Continuous,
     Prismatic,
+    #[default]
     Fixed,
     Floating,
     Planar,
     Spherical,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct JointLimit {
-    #[serde(default)]
     pub lower: f64,
-    #[serde(default)]
     pub upper: f64,
     pub effort: f64,
     pub velocity: f64,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Mimic {
     pub joint: String,
     pub multiplier: Option<f64>,
     pub offset: Option<f64>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct SafetyController {
-    #[serde(default)]
     pub soft_lower_limit: f64,
-    #[serde(default)]
     pub soft_upper_limit: f64,
-    #[serde(default)]
     pub k_position: f64,
     pub k_velocity: f64,
 }
 
 /// Urdf Joint element
 /// See <http://wiki.ros.org/urdf/XML/joint> for more detail.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
 pub struct Joint {
+    #[yaserde(attribute)]
     pub name: String,
-    #[serde(rename = "type")]
+    #[yaserde(rename = "type")]
     pub joint_type: JointType,
-    #[serde(default)]
     pub origin: Pose,
     pub parent: LinkName,
     pub child: LinkName,
-    #[serde(default)]
     pub axis: Axis,
-    #[serde(default)]
     pub limit: JointLimit,
     pub dynamics: Option<Dynamics>,
     pub mimic: Option<Mimic>,
     pub safety_controller: Option<SafetyController>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Dynamics {
-    #[serde(default)]
     pub damping: f64,
-    #[serde(default)]
     pub friction: f64,
 }
 
 /// Top level struct to access urdf.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
 pub struct Robot {
-    #[serde(default)]
+    #[yaserde(attribute)]
     pub name: String,
 
-    #[serde(rename = "link", default)]
+    #[yaserde(rename = "link")]
     pub links: Vec<Link>,
 
-    #[serde(rename = "joint", default)]
+    #[yaserde(rename = "joint")]
     pub joints: Vec<Joint>,
 
-    #[serde(rename = "material", default)]
+    #[yaserde(rename = "material")]
     pub materials: Vec<Material>,
 }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -175,7 +175,7 @@ pub struct Link {
 }
 
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct Vec3([f64; 3]);
+pub struct Vec3(pub [f64; 3]);
 
 impl Deref for Vec3 {
     type Target = [f64; 3];
@@ -240,7 +240,7 @@ impl YaDeserialize for Vec3 {
 }
 
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct Vec4([f64; 4]);
+pub struct Vec4(pub [f64; 4]);
 
 impl Deref for Vec4 {
     type Target = [f64; 4];

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,8 +1,8 @@
-use yaserde::{YaSerialize, YaDeserialize};
-use yaserde::xml::namespace::Namespace;
-use yaserde::xml::attribute::OwnedAttribute;
 use yaserde::xml;
-use yaserde_derive::{YaSerialize, YaDeserialize};
+use yaserde::xml::attribute::OwnedAttribute;
+use yaserde::xml::namespace::Namespace;
+use yaserde::{YaDeserialize, YaSerialize};
+use yaserde_derive::{YaDeserialize, YaSerialize};
 
 use std::io::{Read, Write};
 
@@ -113,7 +113,9 @@ impl From<&GeometrySerde> for Geometry {
 impl Default for GeometrySerde {
     fn default() -> Self {
         Self {
-            box_geometry: Some(BoxGeometry{size: Vec3::default()}),
+            box_geometry: Some(BoxGeometry {
+                size: Vec3::default(),
+            }),
             cylinder: None,
             capsule: None,
             sphere: None,
@@ -190,23 +192,31 @@ impl DerefMut for Vec3 {
 }
 
 impl YaSerialize for Vec3 {
-    fn serialize<W: Write>(&self, serializer: &mut yaserde::ser::Serializer<W>) -> Result<(), String>
-    {
-        serializer.write(xml::writer::XmlEvent::Characters(&format!("{} {} {}", self.0[0], self.0[1], self.0[2]))).map_err(|e| e.to_string())
+    fn serialize<W: Write>(
+        &self,
+        serializer: &mut yaserde::ser::Serializer<W>,
+    ) -> Result<(), String> {
+        serializer
+            .write(xml::writer::XmlEvent::Characters(&format!(
+                "{} {} {}",
+                self.0[0], self.0[1], self.0[2]
+            )))
+            .map_err(|e| e.to_string())
     }
 
     fn serialize_attributes(
-        &self, 
-        attributes: Vec<OwnedAttribute>, 
-        namespace: Namespace
+        &self,
+        attributes: Vec<OwnedAttribute>,
+        namespace: Namespace,
     ) -> Result<(Vec<OwnedAttribute>, Namespace), String> {
         Ok((attributes, namespace))
     }
 }
 
 impl YaDeserialize for Vec3 {
-    fn deserialize<R: Read>(deserializer: &mut yaserde::de::Deserializer<R>) -> Result<Self, String>
-    {
+    fn deserialize<R: Read>(
+        deserializer: &mut yaserde::de::Deserializer<R>,
+    ) -> Result<Self, String> {
         deserializer.next_event()?;
         if let Ok(xml::reader::XmlEvent::Characters(v)) = deserializer.peek() {
             let split_results: Vec<_> = v
@@ -247,23 +257,31 @@ impl DerefMut for Vec4 {
 }
 
 impl YaSerialize for Vec4 {
-    fn serialize<W: Write>(&self, serializer: &mut yaserde::ser::Serializer<W>) -> Result<(), String>
-    {
-        serializer.write(xml::writer::XmlEvent::Characters(&format!("{} {} {} {}", self.0[0], self.0[1], self.0[2], self.0[3]))).map_err(|e| e.to_string())
+    fn serialize<W: Write>(
+        &self,
+        serializer: &mut yaserde::ser::Serializer<W>,
+    ) -> Result<(), String> {
+        serializer
+            .write(xml::writer::XmlEvent::Characters(&format!(
+                "{} {} {} {}",
+                self.0[0], self.0[1], self.0[2], self.0[3]
+            )))
+            .map_err(|e| e.to_string())
     }
 
     fn serialize_attributes(
-        &self, 
-        attributes: Vec<OwnedAttribute>, 
-        namespace: Namespace
+        &self,
+        attributes: Vec<OwnedAttribute>,
+        namespace: Namespace,
     ) -> Result<(Vec<OwnedAttribute>, Namespace), String> {
         Ok((attributes, namespace))
     }
 }
 
 impl YaDeserialize for Vec4 {
-    fn deserialize<R: Read>(deserializer: &mut yaserde::de::Deserializer<R>) -> Result<Self, String>
-    {
+    fn deserialize<R: Read>(
+        deserializer: &mut yaserde::de::Deserializer<R>,
+    ) -> Result<Self, String> {
         deserializer.next_event()?;
         if let xml::reader::XmlEvent::Characters(v) = deserializer.peek()? {
             let split_results: Vec<_> = v

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,6 +1,5 @@
-use yaserde::{YaSerialize, YaDeserialize, Visitor};
+use yaserde::{YaSerialize, YaDeserialize};
 use yaserde::xml::namespace::Namespace;
-use yaserde::ser::Serializer;
 use yaserde::xml::attribute::OwnedAttribute;
 use yaserde::xml;
 use yaserde_derive::{YaSerialize, YaDeserialize};
@@ -74,6 +73,7 @@ pub struct MeshGeometry {
     pub scale: Option<Vec3>,
 }
 
+#[derive(Debug, Clone)]
 pub enum Geometry {
     Box(BoxGeometry),
     Cylinder(CylinderGeometry),
@@ -85,15 +85,11 @@ pub enum Geometry {
 #[derive(Debug, YaDeserialize, YaSerialize, Clone)]
 pub struct GeometrySerde {
     #[yaserde(rename = "box")]
-    pub box_geometry: Option<BoxGeometry>,
-    #[yaserde(rename = "cylinder")]
-    pub cylinder: Option<CylinderGeometry>,
-    #[yaserde(rename = "capsule")]
-    pub capsule: Option<CapsuleGeometry>,
-    #[yaserde(rename = "sphere")]
-    pub sphere: Option<SphereGeometry>,
-    #[yaserde(rename = "mesh")]
-    pub mesh: Option<MeshGeometry>,
+    box_geometry: Option<BoxGeometry>,
+    cylinder: Option<CylinderGeometry>,
+    capsule: Option<CapsuleGeometry>,
+    sphere: Option<SphereGeometry>,
+    mesh: Option<MeshGeometry>,
 }
 
 impl From<&GeometrySerde> for Geometry {
@@ -128,11 +124,13 @@ impl Default for GeometrySerde {
 
 #[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Color {
+    #[yaserde(attribute)]
     pub rgba: Vec4,
 }
 
 #[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Texture {
+    #[yaserde(attribute)]
     pub filename: String,
 }
 
@@ -141,11 +139,14 @@ pub struct Material {
     #[yaserde(attribute)]
     pub name: String,
     pub color: Option<Color>,
+    #[yaserde(attribute)]
     pub texture: Option<Texture>,
 }
 
 #[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Visual {
+    // TODO(luca) check if name is actually implemented
+    #[yaserde(attribute)]
     pub name: Option<String>,
     pub origin: Pose,
     pub geometry: GeometrySerde,
@@ -154,6 +155,7 @@ pub struct Visual {
 
 #[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Collision {
+    #[yaserde(attribute)]
     pub name: Option<String>,
     pub origin: Pose,
     pub geometry: GeometrySerde,
@@ -190,15 +192,9 @@ impl DerefMut for Vec3 {
 impl YaSerialize for Vec3 {
     fn serialize<W: Write>(&self, serializer: &mut yaserde::ser::Serializer<W>) -> Result<(), String>
     {
-        // TODO(luca) cleanup this
-        println!("Serializing {:?}", self);
-        match serializer.write(xml::writer::XmlEvent::Characters(&format!("{} {} {}", self.0[0], self.0[1], self.0[2]))) {
-            Ok(()) => Ok(()),
-            Err(e) => Err(e.to_string()),
-        }
+        serializer.write(xml::writer::XmlEvent::Characters(&format!("{} {} {}", self.0[0], self.0[1], self.0[2]))).map_err(|e| e.to_string())
     }
 
-    // TODO(luca) check this implementation
     fn serialize_attributes(
         &self, 
         attributes: Vec<OwnedAttribute>, 
@@ -211,7 +207,7 @@ impl YaSerialize for Vec3 {
 impl YaDeserialize for Vec3 {
     fn deserialize<R: Read>(deserializer: &mut yaserde::de::Deserializer<R>) -> Result<Self, String>
     {
-        deserializer.next_event();
+        deserializer.next_event()?;
         if let Ok(xml::reader::XmlEvent::Characters(v)) = deserializer.peek() {
             let split_results: Vec<_> = v
                 .split_whitespace()
@@ -253,14 +249,9 @@ impl DerefMut for Vec4 {
 impl YaSerialize for Vec4 {
     fn serialize<W: Write>(&self, serializer: &mut yaserde::ser::Serializer<W>) -> Result<(), String>
     {
-        // TODO(luca) cleanup this
-        match serializer.write(xml::writer::XmlEvent::Characters(&format!("{} {} {} {}", self.0[0], self.0[1], self.0[2], self.0[3]))) {
-            Ok(()) => Ok(()),
-            Err(e) => Err(e.to_string()),
-        }
+        serializer.write(xml::writer::XmlEvent::Characters(&format!("{} {} {} {}", self.0[0], self.0[1], self.0[2], self.0[3]))).map_err(|e| e.to_string())
     }
 
-    // TODO(luca) check this implementation
     fn serialize_attributes(
         &self, 
         attributes: Vec<OwnedAttribute>, 
@@ -273,7 +264,7 @@ impl YaSerialize for Vec4 {
 impl YaDeserialize for Vec4 {
     fn deserialize<R: Read>(deserializer: &mut yaserde::de::Deserializer<R>) -> Result<Self, String>
     {
-        deserializer.next_event();
+        deserializer.next_event()?;
         if let xml::reader::XmlEvent::Characters(v) = deserializer.peek()? {
             let split_results: Vec<_> = v
                 .split_whitespace()
@@ -315,7 +306,6 @@ pub struct LinkName {
     pub link: String,
 }
 
-// TODO(luca) see if we can avoid deriving default
 #[derive(Debug, Default, YaDeserialize, YaSerialize, Clone, PartialEq, Eq)]
 #[yaserde(rename_all = "snake_case")]
 pub enum JointType {

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -80,7 +80,6 @@ impl YaSerialize for Geometry {
             .map_err(|e| e.to_string())?;
         match self {
             Geometry::Box { size } => {
-                dbg!(&format!("{:.1} {:.1} {:.1}", size[0], size[1], size[2]));
                 serializer
                     .write(
                         xml::writer::XmlEvent::start_element("box")

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,5 +1,5 @@
+use serde::de::Visitor;
 use serde::{Deserialize, Serialize};
-use serde::de::{Visitor};
 
 use std::ops::{Deref, DerefMut};
 
@@ -145,19 +145,23 @@ impl<'de> Visitor<'de> for Vec3Visitor {
     type Value = Vec3;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(
-            "a string containing three floating point values separated by spaces",
-        )
+        formatter.write_str("a string containing three floating point values separated by spaces")
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
     where
         E: serde::de::Error,
     {
-        let split_results: Vec<_> = v.split_whitespace().filter_map(|s| s.parse::<f64>().ok()).collect();
+        let split_results: Vec<_> = v
+            .split_whitespace()
+            .filter_map(|s| s.parse::<f64>().ok())
+            .collect();
         if split_results.len() != 3 {
             return Err(E::custom(format!(
-                "Wrong vector element count, expected 3 found {} for [{}]", split_results.len(), v)));
+                "Wrong vector element count, expected 3 found {} for [{}]",
+                split_results.len(),
+                v
+            )));
         }
         let mut res = [0.0f64; 3];
         res.copy_from_slice(&split_results);
@@ -187,7 +191,10 @@ impl Serialize for Vec4 {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&format!("{} {} {} {}", self.0[0], self.0[1], self.0[2], self.0[3]))
+        serializer.serialize_str(&format!(
+            "{} {} {} {}",
+            self.0[0], self.0[1], self.0[2], self.0[3]
+        ))
     }
 }
 
@@ -205,19 +212,23 @@ impl<'de> Visitor<'de> for Vec4Visitor {
     type Value = Vec4;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(
-            "a string containing four floating point values separated by spaces",
-        )
+        formatter.write_str("a string containing four floating point values separated by spaces")
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
     where
         E: serde::de::Error,
     {
-        let split_results: Vec<_> = v.split_whitespace().filter_map(|s| s.parse::<f64>().ok()).collect();
+        let split_results: Vec<_> = v
+            .split_whitespace()
+            .filter_map(|s| s.parse::<f64>().ok())
+            .collect();
         if split_results.len() != 4 {
             return Err(E::custom(format!(
-                "Wrong vector element count, expected 4 found {} for [{}]", split_results.len(), v)));
+                "Wrong vector element count, expected 4 found {} for [{}]",
+                split_results.len(),
+                v
+            )));
         }
         let mut res = [0.0f64; 4];
         res.copy_from_slice(&split_results);

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -181,13 +181,13 @@ impl Deref for Vec3 {
     type Target = [f64; 3];
 
     fn deref(&self) -> &Self::Target {
-        return &self.0;
+        &self.0
     }
 }
 
 impl DerefMut for Vec3 {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        return &mut self.0;
+        &mut self.0
     }
 }
 
@@ -232,9 +232,9 @@ impl YaDeserialize for Vec3 {
             }
             let mut res = [0.0f64; 3];
             res.copy_from_slice(&split_results);
-            return Ok(Vec3(res));
+            Ok(Vec3(res))
         } else {
-            return Err("String of elements not found while parsing Vec3".to_string());
+            Err("String of elements not found while parsing Vec3".to_string())
         }
     }
 }
@@ -246,13 +246,13 @@ impl Deref for Vec4 {
     type Target = [f64; 4];
 
     fn deref(&self) -> &Self::Target {
-        return &self.0;
+        &self.0
     }
 }
 
 impl DerefMut for Vec4 {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        return &mut self.0;
+        &mut self.0
     }
 }
 
@@ -297,9 +297,9 @@ impl YaDeserialize for Vec4 {
             }
             let mut res = [0.0f64; 4];
             res.copy_from_slice(&split_results);
-            return Ok(Vec4(res));
+            Ok(Vec4(res))
         } else {
-            return Err("String of elements not found while parsing Vec3".to_string());
+            Err("String of elements not found while parsing Vec3".to_string())
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,8 +16,6 @@ pub struct UrdfError(#[from] ErrorKind);
 pub(crate) enum ErrorKind {
     #[error(transparent)]
     File(#[from] std::io::Error),
-    #[error(transparent)]
-    RustyXml(#[from] xml::BuilderError),
     #[error("command error {}\n--- stdout\n{}\n--- stderr\n{}", .msg, .stdout, .stderr)]
     Command {
         msg: String,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,6 +48,19 @@ impl From<&str> for UrdfError {
     }
 }
 
+impl From<String> for UrdfError {
+    fn from(err: String) -> UrdfError {
+        ErrorKind::Other(err).into()
+    }
+}
+
+// TODO(luca) why do we need this?
+impl From<String> for ErrorKind {
+    fn from(err: String) -> ErrorKind {
+        ErrorKind::Other(err)
+    }
+}
+
 impl From<std::string::FromUtf8Error> for UrdfError {
     fn from(err: std::string::FromUtf8Error) -> UrdfError {
         ErrorKind::Other(err.to_string()).into()

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,8 +17,6 @@ pub(crate) enum ErrorKind {
     #[error(transparent)]
     File(#[from] std::io::Error),
     #[error(transparent)]
-    Xml(#[from] serde_xml_rs::Error),
-    #[error(transparent)]
     RustyXml(#[from] xml::BuilderError),
     #[error("command error {}\n--- stdout\n{}\n--- stderr\n{}", .msg, .stdout, .stderr)]
     Command {

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -84,7 +84,7 @@ pub fn write_to_string(robot: &Robot) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use crate::{read_from_string, write_to_string};
-    use crate::{BoxGeometry, CylinderGeometry, Geometry, JointType, MeshGeometry, Robot};
+    use crate::{Geometry, JointType, Robot};
     use assert_approx_eq::assert_approx_eq;
 
     fn check_robot(robot: &Robot) {
@@ -102,29 +102,29 @@ mod tests {
         assert_approx_eq!(rpy[1], -0.2);
         assert_approx_eq!(rpy[2], -0.3);
 
-        match (&robot.links[0].visual[0].geometry).into() {
-            Geometry::Box(BoxGeometry { size }) => {
+        match &robot.links[0].visual[0].geometry {
+            Geometry::Box { size } => {
                 assert_approx_eq!(size[0], 1.0f64);
                 assert_approx_eq!(size[1], 2.0f64);
                 assert_approx_eq!(size[2], 3.0f64);
             }
             _ => panic!("geometry error"),
         }
-        match (&robot.links[0].visual[1].geometry).into() {
-            Geometry::Mesh(MeshGeometry {
+        match &robot.links[0].visual[1].geometry {
+            Geometry::Mesh {
                 ref filename,
                 scale,
-            }) => {
+            } => {
                 assert_eq!(filename, "aa.dae");
                 assert!(scale.is_none());
             }
             _ => panic!("geometry error"),
         }
-        match (&robot.links[0].visual[2].geometry).into() {
-            Geometry::Mesh(MeshGeometry {
+        match &robot.links[0].visual[2].geometry {
+            Geometry::Mesh {
                 ref filename,
                 scale,
-            }) => {
+            } => {
                 assert_eq!(filename, "bbb.dae");
                 assert!(scale.is_some());
             }
@@ -132,8 +132,8 @@ mod tests {
         }
 
         assert_eq!(robot.links[0].collision.len(), 1);
-        match (&robot.links[0].collision[0].geometry).into() {
-            Geometry::Cylinder(CylinderGeometry { radius, length }) => {
+        match &robot.links[0].collision[0].geometry {
+            Geometry::Cylinder { radius, length } => {
                 assert_approx_eq!(radius, 1.0);
                 assert_approx_eq!(length, 0.5);
             }
@@ -228,7 +228,7 @@ mod tests {
         let robot = read_from_string(s).unwrap();
         dbg!(&robot);
 
-        //check_robot(&robot);
+        check_robot(&robot);
 
         // Loopback test
         let s = write_to_string(&robot).unwrap();

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -116,10 +116,10 @@ pub fn read_from_string(string: &str) -> Result<Robot> {
 }
 
 pub fn write_to_string(robot: &Robot) -> Result<String> {
-    let conf = yaserde::ser::Config{
+    let conf = yaserde::ser::Config {
         perform_indent: true,
         write_document_declaration: false,
-        indent_string: None
+        indent_string: None,
     };
     yaserde::ser::to_string_with_config(robot, &conf).map_err(UrdfError::new)
 }
@@ -127,7 +127,7 @@ pub fn write_to_string(robot: &Robot) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use crate::{read_from_string, write_to_string};
-    use crate::{BoxGeometry, CylinderGeometry, MeshGeometry, Geometry, Robot};
+    use crate::{BoxGeometry, CylinderGeometry, Geometry, MeshGeometry, Robot};
     use assert_approx_eq::assert_approx_eq;
 
     fn check_robot(robot: &Robot) {
@@ -146,7 +146,7 @@ mod tests {
         assert_approx_eq!(rpy[2], -0.3);
 
         match (&robot.links[0].visual[0].geometry).into() {
-            Geometry::Box(BoxGeometry{size}) => {
+            Geometry::Box(BoxGeometry { size }) => {
                 assert_approx_eq!(size[0], 1.0f64);
                 assert_approx_eq!(size[1], 2.0f64);
                 assert_approx_eq!(size[2], 3.0f64);

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -226,16 +226,11 @@ mod tests {
             </robot>
         "##;
         let robot = read_from_string(s).unwrap();
-        dbg!(&robot);
-
         check_robot(&robot);
 
         // Loopback test
         let s = write_to_string(&robot).unwrap();
-        println!("{}", s);
-
         let robot = read_from_string(&s).unwrap();
-        //dbg!(&robot);
         check_robot(&robot);
     }
 }

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -84,7 +84,7 @@ pub fn write_to_string(robot: &Robot) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use crate::{read_from_string, write_to_string};
-    use crate::{BoxGeometry, CylinderGeometry, Geometry, MeshGeometry, Robot};
+    use crate::{BoxGeometry, CylinderGeometry, Geometry, JointType, MeshGeometry, Robot};
     use assert_approx_eq::assert_approx_eq;
 
     fn check_robot(robot: &Robot) {
@@ -153,6 +153,7 @@ mod tests {
         assert_eq!(robot.joints[0].name, "shoulder_pitch");
         assert_eq!(robot.joints[0].parent.link, "shoulder1");
         assert_eq!(robot.joints[0].child.link, "elbow1");
+        assert_eq!(robot.joints[0].joint_type, JointType::Revolute);
         let xyz = &robot.joints[0].axis.xyz;
         assert_approx_eq!(xyz[0], 0.0f64);
         assert_approx_eq!(xyz[1], 1.0f64);

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -184,16 +184,16 @@ fn it_works() {
     assert_eq!(robot.joints.len(), 2);
     assert_eq!(robot.links[0].visual.len(), 3);
     assert_eq!(robot.links[0].inertial.mass.value, 1.0);
-    let xyz = robot.links[0].visual[0].origin.xyz;
+    let xyz = &robot.links[0].visual[0].origin.xyz;
     assert_approx_eq!(xyz[0], 0.1);
     assert_approx_eq!(xyz[1], 0.2);
     assert_approx_eq!(xyz[2], 0.3);
-    let rpy = robot.links[0].visual[0].origin.rpy;
+    let rpy = &robot.links[0].visual[0].origin.rpy;
     assert_approx_eq!(rpy[0], -0.1);
     assert_approx_eq!(rpy[1], -0.2);
     assert_approx_eq!(rpy[2], -0.3);
 
-    match robot.links[0].visual[0].geometry {
+    match &robot.links[0].visual[0].geometry {
         Geometry::Box { size } => {
             assert_approx_eq!(size[0], 1.0f64);
             assert_approx_eq!(size[1], 2.0f64);
@@ -201,17 +201,17 @@ fn it_works() {
         }
         _ => panic!("geometry error"),
     }
-    match robot.links[0].visual[1].geometry {
+    match &robot.links[0].visual[1].geometry {
         Geometry::Mesh {
             ref filename,
             scale,
         } => {
             assert_eq!(filename, "aa.dae");
-            assert_eq!(scale, None);
+            assert!(scale.is_none());
         }
         _ => panic!("geometry error"),
     }
-    match robot.links[0].visual[2].geometry {
+    match &robot.links[0].visual[2].geometry {
         Geometry::Mesh {
             ref filename,
             scale,
@@ -223,7 +223,7 @@ fn it_works() {
     }
 
     assert_eq!(robot.links[0].collision.len(), 1);
-    match robot.links[0].collision[0].geometry {
+    match &robot.links[0].collision[0].geometry {
         Geometry::Cylinder { radius, length } => {
             assert_approx_eq!(radius, 1.0);
             assert_approx_eq!(length, 0.5);
@@ -234,11 +234,11 @@ fn it_works() {
     assert_eq!(robot.materials.len(), 1);
 
     assert_eq!(robot.joints[0].name, "shoulder_pitch");
-    let xyz = robot.joints[0].axis.xyz;
+    let xyz = &robot.joints[0].axis.xyz;
     assert_approx_eq!(xyz[0], 0.0f64);
     assert_approx_eq!(xyz[1], 1.0f64);
     assert_approx_eq!(xyz[2], -1.0f64);
-    let xyz = robot.joints[0].axis.xyz;
+    let xyz = &robot.joints[0].axis.xyz;
     //"0 1 -1"
     assert_approx_eq!(xyz[0], 0.0);
     assert_approx_eq!(xyz[1], 1.0);

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -69,7 +69,7 @@ pub fn read_file<P: AsRef<Path>>(path: P) -> Result<Robot> {
 /// ```
 
 pub fn read_from_string(string: &str) -> Result<Robot> {
-    yaserde::de::from_str(&string).map_err(UrdfError::new)
+    yaserde::de::from_str(string).map_err(UrdfError::new)
 }
 
 pub fn write_to_string(robot: &Robot) -> Result<String> {

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -115,132 +115,151 @@ pub fn read_from_string(string: &str) -> Result<Robot> {
     serde_xml_rs::from_str(&sorted_string).map_err(UrdfError::new)
 }
 
-#[test]
-fn it_works() {
+pub fn write_to_string(robot: &Robot) -> Result<String> {
+    serde_xml_rs::to_string(robot).map_err(UrdfError::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{read_from_string, write_to_string};
+    use crate::{Geometry, Robot};
     use assert_approx_eq::assert_approx_eq;
 
-    let s = r##"
-        <robot name="robot">
-            <material name="blue">
-              <color rgba="0.0 0.0 0.8 1.0"/>
-            </material>
+    fn check_robot(robot: &Robot) {
+        assert_eq!(robot.name, "robot");
+        assert_eq!(robot.links.len(), 3);
+        assert_eq!(robot.joints.len(), 2);
+        assert_eq!(robot.links[0].visual.len(), 3);
+        assert_eq!(robot.links[0].inertial.mass.value, 1.0);
+        let xyz = &robot.links[0].visual[0].origin.xyz;
+        assert_approx_eq!(xyz[0], 0.1);
+        assert_approx_eq!(xyz[1], 0.2);
+        assert_approx_eq!(xyz[2], 0.3);
+        let rpy = &robot.links[0].visual[0].origin.rpy;
+        assert_approx_eq!(rpy[0], -0.1);
+        assert_approx_eq!(rpy[1], -0.2);
+        assert_approx_eq!(rpy[2], -0.3);
 
-            <link name="shoulder1">
-                <inertial>
-                    <origin xyz="0 0 0.5" rpy="0 0 0"/>
-                    <mass value="1"/>
-                    <inertia ixx="100"  ixy="0"  ixz="0" iyy="100" iyz="0" izz="100" />
-                </inertial>
-                <visual>
-                    <origin xyz="0.1 0.2 0.3" rpy="-0.1 -0.2  -0.3" />
-                    <geometry>
-                        <box size="1.0 2.0 3.0" />
-                    </geometry>
-                    <material name="Cyan">
-                        <color rgba="0 1.0 1.0 1.0"/>
-                    </material>
-                </visual>
-                <visual>
-                    <origin xyz="0.1 0.2 0.3" rpy="-0.1 -0.2  -0.3" />
-                    <geometry>
-                        <mesh filename="aa.dae" />
-                    </geometry>
-                </visual>
-                <collision>
-                    <origin xyz="0 0 0" rpy="0 0 0"/>
-                    <geometry>
-                        <cylinder radius="1" length="0.5"/>
-                    </geometry>
-                </collision>
-                <visual>
-                    <origin xyz="0.1 0.2 0.3" rpy="-0.1 -0.2  -0.3" />
-                    <geometry>
-                        <mesh filename="bbb.dae" scale="2.0 3.0 4.0" />
-                    </geometry>
-                </visual>
-            </link>
-            <joint name="shoulder_pitch" type="revolute">
-                <origin xyz="0.0 0.0 0.1" />
-                <parent link="shoulder1" />
-                <child link="elbow1" />
-                <axis xyz="0 1 -1" />
-                <limit lower="-1" upper="1.0" effort="0" velocity="1.0"/>
-            </joint>
-            <link name="elbow1" />
-            <link name="wrist1" />
-            <joint name="shoulder_pitch" type="revolute">
-                <origin xyz="0.0 0.0 0.0" />
-                <parent link="elbow1" />
-                <child link="wrist1" />
-                <axis xyz="0 1 0" />
-                <limit lower="-2" upper="1.0" effort="0" velocity="1.0"/>
-            </joint>
-        </robot>
-    "##;
-    let robot = read_from_string(s).unwrap();
+        match &robot.links[0].visual[0].geometry {
+            Geometry::Box { size } => {
+                assert_approx_eq!(size[0], 1.0f64);
+                assert_approx_eq!(size[1], 2.0f64);
+                assert_approx_eq!(size[2], 3.0f64);
+            }
+            _ => panic!("geometry error"),
+        }
+        match &robot.links[0].visual[1].geometry {
+            Geometry::Mesh {
+                ref filename,
+                scale,
+            } => {
+                assert_eq!(filename, "aa.dae");
+                assert!(scale.is_none());
+            }
+            _ => panic!("geometry error"),
+        }
+        match &robot.links[0].visual[2].geometry {
+            Geometry::Mesh {
+                ref filename,
+                scale,
+            } => {
+                assert_eq!(filename, "bbb.dae");
+                assert!(scale.is_some());
+            }
+            _ => panic!("geometry error"),
+        }
 
-    assert_eq!(robot.name, "robot");
-    assert_eq!(robot.links.len(), 3);
-    assert_eq!(robot.joints.len(), 2);
-    assert_eq!(robot.links[0].visual.len(), 3);
-    assert_eq!(robot.links[0].inertial.mass.value, 1.0);
-    let xyz = &robot.links[0].visual[0].origin.xyz;
-    assert_approx_eq!(xyz[0], 0.1);
-    assert_approx_eq!(xyz[1], 0.2);
-    assert_approx_eq!(xyz[2], 0.3);
-    let rpy = &robot.links[0].visual[0].origin.rpy;
-    assert_approx_eq!(rpy[0], -0.1);
-    assert_approx_eq!(rpy[1], -0.2);
-    assert_approx_eq!(rpy[2], -0.3);
+        assert_eq!(robot.links[0].collision.len(), 1);
+        match &robot.links[0].collision[0].geometry {
+            Geometry::Cylinder { radius, length } => {
+                assert_approx_eq!(radius, 1.0);
+                assert_approx_eq!(length, 0.5);
+            }
+            _ => panic!("geometry error"),
+        }
 
-    match &robot.links[0].visual[0].geometry {
-        Geometry::Box { size } => {
-            assert_approx_eq!(size[0], 1.0f64);
-            assert_approx_eq!(size[1], 2.0f64);
-            assert_approx_eq!(size[2], 3.0f64);
-        }
-        _ => panic!("geometry error"),
-    }
-    match &robot.links[0].visual[1].geometry {
-        Geometry::Mesh {
-            ref filename,
-            scale,
-        } => {
-            assert_eq!(filename, "aa.dae");
-            assert!(scale.is_none());
-        }
-        _ => panic!("geometry error"),
-    }
-    match &robot.links[0].visual[2].geometry {
-        Geometry::Mesh {
-            ref filename,
-            scale,
-        } => {
-            assert_eq!(filename, "bbb.dae");
-            assert!(scale.is_some());
-        }
-        _ => panic!("geometry error"),
+        assert_eq!(robot.materials.len(), 1);
+
+        assert_eq!(robot.joints[0].name, "shoulder_pitch");
+        let xyz = &robot.joints[0].axis.xyz;
+        assert_approx_eq!(xyz[0], 0.0f64);
+        assert_approx_eq!(xyz[1], 1.0f64);
+        assert_approx_eq!(xyz[2], -1.0f64);
+        let xyz = &robot.joints[0].axis.xyz;
+        //"0 1 -1"
+        assert_approx_eq!(xyz[0], 0.0);
+        assert_approx_eq!(xyz[1], 1.0);
+        assert_approx_eq!(xyz[2], -1.0);
     }
 
-    assert_eq!(robot.links[0].collision.len(), 1);
-    match &robot.links[0].collision[0].geometry {
-        Geometry::Cylinder { radius, length } => {
-            assert_approx_eq!(radius, 1.0);
-            assert_approx_eq!(length, 0.5);
-        }
-        _ => panic!("geometry error"),
+    #[test]
+    fn deserialization() {
+        let s = r##"
+            <robot name="robot">
+                <material name="blue">
+                  <color rgba="0.0 0.0 0.8 1.0"/>
+                </material>
+
+                <link name="shoulder1">
+                    <inertial>
+                        <origin xyz="0 0 0.5" rpy="0 0 0"/>
+                        <mass value="1"/>
+                        <inertia ixx="100"  ixy="0"  ixz="0" iyy="100" iyz="0" izz="100" />
+                    </inertial>
+                    <visual>
+                        <origin xyz="0.1 0.2 0.3" rpy="-0.1 -0.2  -0.3" />
+                        <geometry>
+                            <box size="1.0 2.0 3.0" />
+                        </geometry>
+                        <material name="Cyan">
+                            <color rgba="0 1.0 1.0 1.0"/>
+                        </material>
+                    </visual>
+                    <visual>
+                        <origin xyz="0.1 0.2 0.3" rpy="-0.1 -0.2  -0.3" />
+                        <geometry>
+                            <mesh filename="aa.dae" />
+                        </geometry>
+                    </visual>
+                    <collision>
+                        <origin xyz="0 0 0" rpy="0 0 0"/>
+                        <geometry>
+                            <cylinder radius="1" length="0.5"/>
+                        </geometry>
+                    </collision>
+                    <visual>
+                        <origin xyz="0.1 0.2 0.3" rpy="-0.1 -0.2  -0.3" />
+                        <geometry>
+                            <mesh filename="bbb.dae" scale="2.0 3.0 4.0" />
+                        </geometry>
+                    </visual>
+                </link>
+                <joint name="shoulder_pitch" type="revolute">
+                    <origin xyz="0.0 0.0 0.1" />
+                    <parent link="shoulder1" />
+                    <child link="elbow1" />
+                    <axis xyz="0 1 -1" />
+                    <limit lower="-1" upper="1.0" effort="0" velocity="1.0"/>
+                </joint>
+                <link name="elbow1" />
+                <link name="wrist1" />
+                <joint name="shoulder_pitch" type="revolute">
+                    <origin xyz="0.0 0.0 0.0" />
+                    <parent link="elbow1" />
+                    <child link="wrist1" />
+                    <axis xyz="0 1 0" />
+                    <limit lower="-2" upper="1.0" effort="0" velocity="1.0"/>
+                </joint>
+            </robot>
+        "##;
+        let robot = read_from_string(s).unwrap();
+
+        check_robot(&robot);
+
+        // Loopback test
+        let s = write_to_string(&robot).unwrap();
+
+        let robot = read_from_string(&s).unwrap();
+        check_robot(&robot);
     }
-
-    assert_eq!(robot.materials.len(), 1);
-
-    assert_eq!(robot.joints[0].name, "shoulder_pitch");
-    let xyz = &robot.joints[0].axis.xyz;
-    assert_approx_eq!(xyz[0], 0.0f64);
-    assert_approx_eq!(xyz[1], 1.0f64);
-    assert_approx_eq!(xyz[2], -1.0f64);
-    let xyz = &robot.joints[0].axis.xyz;
-    //"0 1 -1"
-    assert_approx_eq!(xyz[0], 0.0);
-    assert_approx_eq!(xyz[1], 1.0);
-    assert_approx_eq!(xyz[2], -1.0);
 }

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -145,7 +145,7 @@ mod tests {
         assert_approx_eq!(rpy[1], -0.2);
         assert_approx_eq!(rpy[2], -0.3);
 
-        match Geometry::from(&robot.links[0].visual[0].geometry) {
+        match (&robot.links[0].visual[0].geometry).into() {
             Geometry::Box(BoxGeometry{size}) => {
                 assert_approx_eq!(size[0], 1.0f64);
                 assert_approx_eq!(size[1], 2.0f64);
@@ -153,7 +153,7 @@ mod tests {
             }
             _ => panic!("geometry error"),
         }
-        match Geometry::from(&robot.links[0].visual[1].geometry) {
+        match (&robot.links[0].visual[1].geometry).into() {
             Geometry::Mesh(MeshGeometry {
                 ref filename,
                 scale,
@@ -163,7 +163,7 @@ mod tests {
             }
             _ => panic!("geometry error"),
         }
-        match Geometry::from(&robot.links[0].visual[2].geometry) {
+        match (&robot.links[0].visual[2].geometry).into() {
             Geometry::Mesh(MeshGeometry {
                 ref filename,
                 scale,
@@ -175,7 +175,7 @@ mod tests {
         }
 
         assert_eq!(robot.links[0].collision.len(), 1);
-        match Geometry::from(&robot.links[0].collision[0].geometry) {
+        match (&robot.links[0].collision[0].geometry).into() {
             Geometry::Cylinder(CylinderGeometry { radius, length }) => {
                 assert_approx_eq!(radius, 1.0);
                 assert_approx_eq!(length, 0.5);
@@ -184,6 +184,14 @@ mod tests {
         }
 
         assert_eq!(robot.materials.len(), 1);
+        let mat = &robot.materials[0];
+        assert_eq!(mat.name, "blue");
+        assert!(mat.color.is_some());
+        let rgba = mat.color.clone().unwrap().rgba;
+        assert_approx_eq!(rgba[0], 0.0);
+        assert_approx_eq!(rgba[1], 0.0);
+        assert_approx_eq!(rgba[2], 0.8);
+        assert_approx_eq!(rgba[3], 1.0);
 
         assert_eq!(robot.joints[0].name, "shoulder_pitch");
         assert_eq!(robot.joints[0].parent.link, "shoulder1");
@@ -262,7 +270,7 @@ mod tests {
         let robot = read_from_string(s).unwrap();
         dbg!(&robot);
 
-        check_robot(&robot);
+        //check_robot(&robot);
 
         // Loopback test
         let s = write_to_string(&robot).unwrap();


### PR DESCRIPTION
:warning: This PR is a pretty large change to the library itself and I believe it might need careful review / changes to make sure it is OK from both a functionality and style point of view. :warning: 

**TLDR**: Switch implementation from `serde-xml-rs` to `yaserde` and derive serialization traits to allow users to also save their structs into a urdf file, as opposed to what it was before that was only allowing deserialization.

## Why yaserde?

I'm working on a "urdf editor" project, so while deserializing urdf is great I would need to be able to also serialize it back to save my changes.
When trying to derive `Serialize` I noticed that it's currently impossible to tell `serde` whether a field should be saved in a child element or in an attribute, for example if we had a struct:

```
struct Element {
    pub child: String
}
```

It could be serialized in any of the following ways, depending on whether `child` should be serialized as a child element or as an attribute:

```
<element>
    <child>content</child>
</element>
```

Or

```
<element child="content" />
```

Serde does not allow tagging fields to change the serialization behavior so the serializer can't be told exactly what to do. It defaults to using child elements (first behavior) but that is not enough for urdf that makes extensive use of attributes.
The discussion started [here](https://github.com/RReverser/serde-xml-rs/issues/49), with the `serde` maintainer [mentioning](https://github.com/serde-rs/serde/issues/1152) that xml should use a different crate, which sparked the creation of [yaserde](https://github.com/media-io/yaserde) that is specific for xml.

`yaserde` allows specifying for each field whether it is an attribute or a child by adding a feature `[yaserde(attribute)]`, child is implied.
The rest of the APIs, such as flattening, renaming, are mostly similar to the `serde` crate.

## The good

* The crate is not affected by the issue with disjoint repeated elements that prompted the creation of the workaround [here](https://github.com/openrr/urdf-rs/blob/f206a67b092db4f2fc122700a2dae0b4abd0dbdc/src/funcs.rs#L6-L46), it can be safely removed.
* Because of the above we can remove dependency on RustyXML, making the crate a bit leaner. The `serde` dependency has been migrated to `yaserde`.
* Serialization works, I updated the unit tests to do a loopback test, where I read the urdf, parse it into a struct, make sure it is correct, then save it and load it back to perform the same check, and the test passes. This means that, at least for the test urdf, serialization and deserialization both work.

## The bad

`yaserde` seems to have a few issues when generating serialization code for enums with struct fields, as documented in this [issue](https://github.com/media-io/yaserde/issues/129#issuecomment-1484766098). This forced me to rewrite serialization and deserialization for geometries manually. Unit tests pass but the surface for bugs is a lot higher. The code should be able to be removed once the upstream issue is fixed.

## Migration Guide

* `Vec3` and `Vec4` types have been added for consistency, together with `Deref` and `DerefMut` implementations, types that were raw arrays are now vectors. If your code expects an array either add a tuple index or dereference operator, as such:

```
// Before
let axis: [f64; 3] = joint.axis.xyz;

// After, either will work
let axis: [f64; 3] = *joint.axis.xyz;
let axis: [f64; 3] = joint.axis.xyz.0;
```