### PR TITLE
Bump yaserde to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ repository = "https://github.com/openrr/urdf-rs"
 [dependencies]
 once_cell = "1"
 regex = "1.4.2"
-yaserde = "0.7.0"
-yaserde_derive = "0.7.0"
+yaserde = "0.8.0"
+yaserde_derive = "0.8.0"
 thiserror = "1.0.7"
 
 [dev-dependencies]

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,6 +1,6 @@
-use yaserde::xml;
-use yaserde::xml::attribute::OwnedAttribute;
-use yaserde::xml::namespace::Namespace;
+use xml::attribute::OwnedAttribute;
+use xml::namespace::Namespace;
+use yaserde::__xml as xml;
 use yaserde::{YaDeserialize, YaSerialize};
 use yaserde_derive::{YaDeserialize, YaSerialize};
 


### PR DESCRIPTION
I didn't notice that `yaserde` had a newer version! Context [here](https://github.com/openrr/urdf-rs/pull/64#issuecomment-1507954870)