### PR TITLE
Fix yaserde deserialization of Joint limits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urdf-rs"
-version = "0.7.2"
+version = "0.7.1"
 authors = ["Takashi Ogura <t.ogura@gmail.com>"]
 edition = "2021"
 description = "URDF parser using serde-xml-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urdf-rs"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Takashi Ogura <t.ogura@gmail.com>"]
 edition = "2021"
 description = "URDF parser using serde-xml-rs"

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -443,9 +443,13 @@ pub enum JointType {
 
 #[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct JointLimit {
+    #[yaserde(attribute)]
     pub lower: f64,
+    #[yaserde(attribute)]
     pub upper: f64,
+    #[yaserde(attribute)]
     pub effort: f64,
+    #[yaserde(attribute)]
     pub velocity: f64,
 }
 

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -154,6 +154,10 @@ mod tests {
         assert_eq!(robot.joints[0].parent.link, "shoulder1");
         assert_eq!(robot.joints[0].child.link, "elbow1");
         assert_eq!(robot.joints[0].joint_type, JointType::Revolute);
+        assert_approx_eq!(robot.joints[0].limit.upper, 1.0);
+        assert_approx_eq!(robot.joints[0].limit.lower, -1.0);
+        assert_approx_eq!(robot.joints[0].limit.effort, 0.0);
+        assert_approx_eq!(robot.joints[0].limit.velocity, 1.0);
         let xyz = &robot.joints[0].axis.xyz;
         assert_approx_eq!(xyz[0], 0.0f64);
         assert_approx_eq!(xyz[1], 1.0f64);


### PR DESCRIPTION
This fixes the bug described in this [#64 comment](https://github.com/openrr/urdf-rs/pull/64#issuecomment-1530954286).

