### PR TITLE
Remove contributors list from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,6 @@ let joints = urdf_robot.joints;
 println!("{:?}", joints[0].origin.xyz);
 ```
 
-## Contributors
-
-<a href="https://github.com/openrr/urdf-rs/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=openrr/urdf-rs" />
-</a>
-
-Made with [contrib.rocks](https://contrib.rocks).
-
 ## `OpenRR` Community
 
 [Here](https://discord.gg/8DAFFKc88B) is a discord server for `OpenRR` users and developers.


### PR DESCRIPTION
GitHub already provides an equivalent.

<img width="845" alt="dup" src="https://github.com/openrr/urdf-rs/assets/43724913/8ebf9739-1d32-49b3-9499-a7f0c223f320">
