### PR TITLE
Update yaserde to 0.8 and handle namespace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ repository = "https://github.com/openrr/urdf-rs"
 [dependencies]
 once_cell = "1"
 regex = "1.4.2"
-yaserde = "0.7.0"
-yaserde_derive = "0.7.0"
 thiserror = "1.0.7"
+xml-rs = "0.8.3"
+yaserde = "0.8"
+yaserde_derive = "0.8"
 
 [dev-dependencies]
 assert_approx_eq = "1"

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,6 +1,5 @@
-use yaserde::xml;
-use yaserde::xml::attribute::OwnedAttribute;
-use yaserde::xml::namespace::Namespace;
+use xml::attribute::OwnedAttribute;
+use xml::namespace::Namespace;
 use yaserde::{YaDeserialize, YaSerialize};
 use yaserde_derive::{YaDeserialize, YaSerialize};
 
@@ -503,7 +502,7 @@ pub struct Dynamics {
 
 /// Top level struct to access urdf.
 #[derive(Debug, YaDeserialize, YaSerialize, Clone)]
-#[yaserde(rename = "robot")]
+#[yaserde(rename = "robot", namespace = "http://www.ros.org")]
 pub struct Robot {
     #[yaserde(attribute)]
     pub name: String,

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn deserialization() {
         let s = r#"
-            <robot name="robot">
+            <robot name="robot" xmlns="http://www.ros.org">
                 <material name="blue">
                   <color rgba="0.0 0.0 0.8 1.0"/>
                 </material>


### PR DESCRIPTION
Fixes #87

In 0.8, there is a problem that the re-export of xml-rs crate no longer being a public API (https://github.com/openrr/urdf-rs/pull/67#discussion_r1166357242)
However, even if they made the re-exports not public APIs, we can still depend on the same version of xml-rs because xml-rs is a public dependency of their APIs anyway.

Ideally I would like them to make re-export a public API again, though. https://github.com/media-io/yaserde/issues/135

Note: This is a breaking change because yaserde is a public dependency.