### PR TITLE
Improve error messages

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -59,7 +59,7 @@ pub fn rospack_find(package: &str) -> Result<String> {
                 .output()
         })
         .map_err(|e| {
-            format!("failed to execute neither rospack nor ros2; consider installing ROS or replacing 'package://' with path: {e}")
+            format!("failed to execute neither `rospack` nor `ros2 pkg`; consider installing ROS or replacing 'package://' with path: {e}")
         })?;
     if output.status.success() {
         Ok(String::from_utf8(output.stdout)?.trim().to_string())


### PR DESCRIPTION
Note: This is a breaking change because this changes `utils::{rospack_find,expand_package_path}` to return `Result`. (Our main branch already contains another breaking change: #88)