### PR TITLE
Migrate to quick-xml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ keywords = ["robotics", "robot", "ros", "urdf"]
 categories = ["data-structures", "parsing"]
 repository = "https://github.com/openrr/urdf-rs"
 
-# Note: yaserde is public dependency.
 [dependencies]
 once_cell = "1"
 regex = "1.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ repository = "https://github.com/openrr/urdf-rs"
 [dependencies]
 once_cell = "1"
 regex = "1.4.2"
-thiserror = "1.0.7"
+thiserror = "1.0.56"
 xml-rs = "0.8.3"
-yaserde = { version = "0.9", features = ["yaserde_derive"] }
+quick-xml = {version = "0.31", features = ["overlapped-lists", "serialize"]}
+serde = {version = "1.0", features = ["derive"]}
 
 [dev-dependencies]
 assert_approx_eq = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/openrr/urdf-rs"
 [dependencies]
 once_cell = "1"
 regex = "1.4.2"
-thiserror = "1.0.56"
+thiserror = "1.0.7"
 xml-rs = "0.8.3"
 quick-xml = {version = "0.31", features = ["overlapped-lists", "serialize"]}
 serde = {version = "1.0", features = ["derive"]}

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -72,9 +72,7 @@ pub struct GeometryTag {
 
 impl From<Geometry> for GeometryTag {
     fn from(geom: Geometry) -> Self {
-        Self {
-            value: geom,
-        }
+        Self { value: geom }
     }
 }
 

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -67,7 +67,7 @@ pub enum Geometry {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct GeometryTag {
     #[serde(rename = "$value")]
-    value: Geometry,
+    pub value: Geometry,
 }
 
 impl Deref for GeometryTag {

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,290 +1,149 @@
-use xml::attribute::OwnedAttribute;
-use xml::namespace::Namespace;
-use yaserde::{YaDeserialize, YaSerialize};
+use serde::{Deserialize, Serialize};
 
-use std::io::{Read, Write};
-
-use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Mass {
-    #[yaserde(attribute)]
+    #[serde(rename = "@value")]
     pub value: f64,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Inertia {
-    #[yaserde(attribute)]
+    #[serde(rename = "@ixx")]
     pub ixx: f64,
-    #[yaserde(attribute)]
+    #[serde(rename = "@ixy")]
     pub ixy: f64,
-    #[yaserde(attribute)]
+    #[serde(rename = "@ixz")]
     pub ixz: f64,
-    #[yaserde(attribute)]
+    #[serde(rename = "@iyy")]
     pub iyy: f64,
-    #[yaserde(attribute)]
+    #[serde(rename = "@iyz")]
     pub iyz: f64,
-    #[yaserde(attribute)]
+    #[serde(rename = "@izz")]
     pub izz: f64,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Inertial {
+    #[serde(default)]
     pub origin: Pose,
     pub mass: Mass,
     pub inertia: Inertia,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum Geometry {
     Box {
+        #[serde(rename = "@size")]
         size: Vec3,
     },
     Cylinder {
+        #[serde(rename = "@radius")]
         radius: f64,
+        #[serde(rename = "@length")]
         length: f64,
     },
     Capsule {
+        #[serde(rename = "@radius")]
         radius: f64,
+        #[serde(rename = "@length")]
         length: f64,
     },
     Sphere {
+        #[serde(rename = "@radius")]
         radius: f64,
     },
     Mesh {
+        #[serde(rename = "@filename")]
         filename: String,
+        #[serde(rename = "@scale")]
+        #[serde(skip_serializing_if = "Option::is_none")]
         scale: Option<Vec3>,
     },
 }
 
-impl Default for Geometry {
-    fn default() -> Self {
-        Self::Box {
-            size: Vec3::default(),
-        }
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct GeometryTag {
+    #[serde(rename = "$value")]
+    value: Geometry,
+}
+
+impl Deref for GeometryTag {
+    type Target = Geometry;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
     }
 }
 
-// TODO(anyone) Derive YaSerialize and YaSerialize and remove custom impl once upstream bug is fixed
-// https://github.com/media-io/yaserde/issues/129
-impl YaSerialize for Geometry {
-    fn serialize<W: Write>(
-        &self,
-        serializer: &mut yaserde::ser::Serializer<W>,
-    ) -> Result<(), String> {
-        serializer
-            .write(xml::writer::XmlEvent::start_element("geometry"))
-            .map_err(|e| e.to_string())?;
-        match self {
-            Geometry::Box { size } => {
-                serializer
-                    .write(
-                        xml::writer::XmlEvent::start_element("box")
-                            .attr("size", &format!("{} {} {}", size[0], size[1], size[2])),
-                    )
-                    .map_err(|e| e.to_string())?;
-            }
-            Geometry::Cylinder { radius, length } => {
-                serializer
-                    .write(
-                        xml::writer::XmlEvent::start_element("cylinder")
-                            .attr("radius", &radius.to_string())
-                            .attr("length", &length.to_string()),
-                    )
-                    .map_err(|e| e.to_string())?;
-            }
-            Geometry::Capsule { radius, length } => {
-                serializer
-                    .write(
-                        xml::writer::XmlEvent::start_element("capsule")
-                            .attr("radius", &radius.to_string())
-                            .attr("length", &length.to_string()),
-                    )
-                    .map_err(|e| e.to_string())?;
-            }
-            Geometry::Sphere { radius } => {
-                serializer
-                    .write(
-                        xml::writer::XmlEvent::start_element("sphere")
-                            .attr("radius", &radius.to_string()),
-                    )
-                    .map_err(|e| e.to_string())?;
-            }
-            Geometry::Mesh { filename, scale } => {
-                let builder =
-                    xml::writer::XmlEvent::start_element("mesh").attr("filename", filename);
-                if let Some(scale) = scale {
-                    serializer
-                        .write(
-                            builder
-                                .attr("scale", &format!("{} {} {}", scale[0], scale[1], scale[2])),
-                        )
-                        .map_err(|e| e.to_string())?;
-                } else {
-                    serializer.write(builder).map_err(|e| e.to_string())?;
-                }
-            }
-        }
-        serializer
-            .write(xml::writer::XmlEvent::end_element())
-            .map_err(|e| e.to_string())?;
-        serializer
-            .write(xml::writer::XmlEvent::end_element())
-            .map_err(|e| e.to_string())?;
-        Ok(())
-    }
-
-    fn serialize_attributes(
-        &self,
-        attributes: Vec<OwnedAttribute>,
-        namespace: Namespace,
-    ) -> Result<(Vec<OwnedAttribute>, Namespace), String> {
-        Ok((attributes, namespace))
+impl DerefMut for GeometryTag {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
     }
 }
 
-impl Vec3 {
-    fn from_string(v: &String) -> Result<Self, String> {
-        let split_results: Vec<_> = v
-            .split_whitespace()
-            .filter_map(|s| s.parse::<f64>().ok())
-            .collect();
-        if split_results.len() != 3 {
-            return Err(format!(
-                "Wrong vector element count, expected 3 found {} for [{}]",
-                split_results.len(),
-                v
-            ));
-        }
-        let mut res = [0.0f64; 3];
-        res.copy_from_slice(&split_results);
-        Ok(Vec3(res))
-    }
-}
-
-impl YaDeserialize for Geometry {
-    fn deserialize<R: Read>(
-        deserializer: &mut yaserde::de::Deserializer<R>,
-    ) -> Result<Self, String> {
-        deserializer.next_event()?;
-        if let Ok(xml::reader::XmlEvent::StartElement {
-            name,
-            attributes,
-            namespace: _,
-        }) = deserializer.peek()
-        {
-            let attributes: HashMap<_, _> = attributes
-                .iter()
-                .map(|attr| (attr.name.local_name.clone(), attr.value.clone()))
-                .collect();
-            if name.local_name == "box" {
-                if let Some(v) = attributes.get("size") {
-                    Ok(Self::Box {
-                        size: Vec3::from_string(v)?,
-                    })
-                } else {
-                    Err(format!(
-                        "Failed parsing attributes for box {:?}",
-                        attributes
-                    ))
-                }
-            } else if name.local_name == "cylinder" {
-                if let (Some(length), Some(radius)) = (
-                    attributes.get("length").and_then(|a| a.parse::<f64>().ok()),
-                    attributes.get("radius").and_then(|a| a.parse::<f64>().ok()),
-                ) {
-                    Ok(Self::Cylinder { length, radius })
-                } else {
-                    Err("Failed parsing radius and size for cylinder geometry".to_string())
-                }
-            } else if name.local_name == "capsule" {
-                if let (Some(length), Some(radius)) = (
-                    attributes.get("length").and_then(|a| a.parse::<f64>().ok()),
-                    attributes.get("radius").and_then(|a| a.parse::<f64>().ok()),
-                ) {
-                    Ok(Self::Capsule { length, radius })
-                } else {
-                    Err("Failed parsing radius and size for capsule geometry".to_string())
-                }
-            } else if name.local_name == "sphere" {
-                if let Some(radius) = attributes.get("radius").and_then(|a| a.parse::<f64>().ok()) {
-                    Ok(Self::Sphere { radius })
-                } else {
-                    Err("Failed parsing radius and size for sphere geometry".to_string())
-                }
-            } else if name.local_name == "mesh" {
-                if let Some(filename) = attributes
-                    .get("filename")
-                    .and_then(|a| a.parse::<String>().ok())
-                {
-                    let scale = attributes
-                        .get("scale")
-                        .and_then(|s| Vec3::from_string(s).ok());
-                    Ok(Self::Mesh { filename, scale })
-                } else {
-                    Err("Error parsing filename for mesh".to_string())
-                }
-            } else {
-                Err(format!("Invalid geometry name [{}] found", name.local_name))
-            }
-        } else {
-            Err("Elements not found while parsing Geometry".to_string())
-        }
-    }
-}
-
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Color {
-    #[yaserde(attribute)]
+    #[serde(rename = "@rgba")]
     pub rgba: Vec4,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Texture {
-    #[yaserde(attribute)]
+    #[serde(rename = "@filename")]
     pub filename: String,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Material {
-    #[yaserde(attribute)]
+    #[serde(rename = "@name")]
     pub name: String,
     pub color: Option<Color>,
-    #[yaserde(attribute)]
+    #[serde(rename = "@texture")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub texture: Option<Texture>,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Visual {
-    #[yaserde(attribute)]
+    #[serde(rename = "@name")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(default)]
     pub origin: Pose,
-    pub geometry: Geometry,
+    pub geometry: GeometryTag,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub material: Option<Material>,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Collision {
-    #[yaserde(attribute)]
+    #[serde(rename = "@name")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(default)]
     pub origin: Pose,
-    pub geometry: Geometry,
+    pub geometry: GeometryTag,
 }
 
 /// Urdf Link element
 /// See <http://wiki.ros.org/urdf/XML/link> for more detail.
-#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Link {
-    #[yaserde(attribute)]
+    #[serde(rename = "@name")]
     pub name: String,
+    #[serde(default)]
     pub inertial: Inertial,
+    #[serde(default)]
     pub visual: Vec<Visual>,
+    #[serde(default)]
     pub collision: Vec<Collision>,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct Vec3(pub [f64; 3]);
+#[derive(Debug, Deserialize, Serialize, Default, Clone, Copy, PartialEq)]
+pub struct Vec3(#[serde(rename = "$text")] pub [f64; 3]);
 
 impl Deref for Vec3 {
     type Target = [f64; 3];
@@ -300,43 +159,8 @@ impl DerefMut for Vec3 {
     }
 }
 
-impl YaSerialize for Vec3 {
-    fn serialize<W: Write>(
-        &self,
-        serializer: &mut yaserde::ser::Serializer<W>,
-    ) -> Result<(), String> {
-        serializer
-            .write(xml::writer::XmlEvent::Characters(&format!(
-                "{} {} {}",
-                self.0[0], self.0[1], self.0[2]
-            )))
-            .map_err(|e| e.to_string())
-    }
-
-    fn serialize_attributes(
-        &self,
-        attributes: Vec<OwnedAttribute>,
-        namespace: Namespace,
-    ) -> Result<(Vec<OwnedAttribute>, Namespace), String> {
-        Ok((attributes, namespace))
-    }
-}
-
-impl YaDeserialize for Vec3 {
-    fn deserialize<R: Read>(
-        deserializer: &mut yaserde::de::Deserializer<R>,
-    ) -> Result<Self, String> {
-        deserializer.next_event()?;
-        if let Ok(xml::reader::XmlEvent::Characters(v)) = deserializer.peek() {
-            Ok(Vec3::from_string(v)?)
-        } else {
-            Err("String of elements not found while parsing Vec3".to_string())
-        }
-    }
-}
-
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct Vec4(pub [f64; 4]);
+#[derive(Debug, Serialize, Deserialize, Default, Clone, Copy, PartialEq)]
+pub struct Vec4(#[serde(rename = "$text")] pub [f64; 4]);
 
 impl Deref for Vec4 {
     type Target = [f64; 4];
@@ -352,166 +176,125 @@ impl DerefMut for Vec4 {
     }
 }
 
-impl YaSerialize for Vec4 {
-    fn serialize<W: Write>(
-        &self,
-        serializer: &mut yaserde::ser::Serializer<W>,
-    ) -> Result<(), String> {
-        serializer
-            .write(xml::writer::XmlEvent::Characters(&format!(
-                "{} {} {} {}",
-                self.0[0], self.0[1], self.0[2], self.0[3]
-            )))
-            .map_err(|e| e.to_string())
-    }
-
-    fn serialize_attributes(
-        &self,
-        attributes: Vec<OwnedAttribute>,
-        namespace: Namespace,
-    ) -> Result<(Vec<OwnedAttribute>, Namespace), String> {
-        Ok((attributes, namespace))
-    }
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct Axis {
+    #[serde(rename = "@xyz")]
+    pub xyz: Vec3,
 }
 
-impl YaDeserialize for Vec4 {
-    fn deserialize<R: Read>(
-        deserializer: &mut yaserde::de::Deserializer<R>,
-    ) -> Result<Self, String> {
-        deserializer.next_event()?;
-        if let xml::reader::XmlEvent::Characters(v) = deserializer.peek()? {
-            let split_results: Vec<_> = v
-                .split_whitespace()
-                .filter_map(|s| s.parse::<f64>().ok())
-                .collect();
-            if split_results.len() != 4 {
-                return Err(format!(
-                    "Wrong vector element count, expected 4 found {} for [{}]",
-                    split_results.len(),
-                    v
-                ));
-            }
-            let mut res = [0.0f64; 4];
-            res.copy_from_slice(&split_results);
-            Ok(Vec4(res))
-        } else {
-            Err("String of elements not found while parsing Vec4".to_string())
+impl Default for Axis {
+    fn default() -> Axis {
+        Axis {
+            xyz: Vec3([1.0, 0.0, 0.0]),
         }
     }
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
-pub struct Axis {
-    #[yaserde(attribute)]
-    pub xyz: Vec3,
-}
-
-#[derive(Debug, Default, YaDeserialize, YaSerialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct Pose {
-    #[yaserde(attribute)]
+    #[serde(rename = "@xyz", default)]
     pub xyz: Vec3,
-    #[yaserde(attribute)]
+    #[serde(rename = "@rpy", default)]
     pub rpy: Vec3,
 }
 
-#[derive(Debug, Default, YaDeserialize, YaSerialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct LinkName {
-    #[yaserde(attribute)]
+    #[serde(rename = "@link")]
     pub link: String,
 }
 
-#[derive(Debug, Default, YaDeserialize, YaSerialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum JointType {
-    #[yaserde(rename = "revolute")]
     Revolute,
-    #[yaserde(rename = "continuous")]
     Continuous,
-    #[yaserde(rename = "prismatic")]
     Prismatic,
-    #[default]
-    #[yaserde(rename = "fixed")]
     Fixed,
-    #[yaserde(rename = "floating")]
     Floating,
-    #[yaserde(rename = "planar")]
     Planar,
-    #[yaserde(rename = "spherical")]
     Spherical,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct JointLimit {
-    #[yaserde(attribute)]
+    #[serde(rename = "@lower", default)]
     pub lower: f64,
-    #[yaserde(attribute)]
+    #[serde(rename = "@upper", default)]
     pub upper: f64,
-    #[yaserde(attribute)]
+    #[serde(rename = "@effort")]
     pub effort: f64,
-    #[yaserde(attribute)]
+    #[serde(rename = "@velocity")]
     pub velocity: f64,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Mimic {
-    #[yaserde(attribute)]
+    #[serde(rename = "@joint")]
     pub joint: String,
-    #[yaserde(attribute)]
+    #[serde(rename = "@multiplier")]
     pub multiplier: Option<f64>,
-    #[yaserde(attribute)]
+    #[serde(rename = "@offset")]
     pub offset: Option<f64>,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct SafetyController {
-    #[yaserde(attribute)]
+    #[serde(rename = "@soft_lower_limit", default)]
     pub soft_lower_limit: f64,
-    #[yaserde(attribute)]
+    #[serde(rename = "@soft_upper_limit", default)]
     pub soft_upper_limit: f64,
-    #[yaserde(attribute)]
+    #[serde(rename = "@k_position", default)]
     pub k_position: f64,
-    #[yaserde(attribute)]
+    #[serde(rename = "@k_velocity")]
     pub k_velocity: f64,
 }
 
 /// Urdf Joint element
 /// See <http://wiki.ros.org/urdf/XML/joint> for more detail.
-#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Joint {
-    #[yaserde(attribute)]
+    #[serde(rename = "@name")]
     pub name: String,
-    #[yaserde(attribute, rename = "type")]
+    #[serde(rename = "@type")]
     pub joint_type: JointType,
+    #[serde(default)]
     pub origin: Pose,
     pub parent: LinkName,
     pub child: LinkName,
+    #[serde(default)]
     pub axis: Axis,
+    #[serde(default)]
     pub limit: JointLimit,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dynamics: Option<Dynamics>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mimic: Option<Mimic>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub safety_controller: Option<SafetyController>,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Dynamics {
-    #[yaserde(attribute)]
+    #[serde(rename = "@damping", default)]
     pub damping: f64,
-    #[yaserde(attribute)]
+    #[serde(rename = "@friction", default)]
     pub friction: f64,
 }
 
 /// Top level struct to access urdf.
-#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
-#[yaserde(rename = "robot", namespace = "http://www.ros.org")]
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename = "robot")]
 pub struct Robot {
-    #[yaserde(attribute)]
+    #[serde(rename = "@name", default)]
     pub name: String,
 
-    #[yaserde(rename = "link")]
+    #[serde(rename = "link", default)]
     pub links: Vec<Link>,
 
-    #[yaserde(rename = "joint")]
+    #[serde(rename = "joint", default)]
     pub joints: Vec<Joint>,
 
-    #[yaserde(rename = "material")]
+    #[serde(rename = "material", default)]
     pub materials: Vec<Material>,
 }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -225,7 +225,7 @@ pub struct JointLimit {
     pub lower: f64,
     #[serde(rename = "@upper", default)]
     pub upper: f64,
-    #[serde(rename = "@effort")]
+    #[serde(rename = "@effort", default)]
     pub effort: f64,
     #[serde(rename = "@velocity")]
     pub velocity: f64,

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -70,6 +70,14 @@ pub struct GeometryTag {
     pub value: Geometry,
 }
 
+impl From<Geometry> for GeometryTag {
+    fn from(geom: Geometry) -> Self {
+        Self {
+            value: geom,
+        }
+    }
+}
+
 impl Deref for GeometryTag {
     type Target = Geometry;
 

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -58,8 +58,7 @@ pub enum Geometry {
     Mesh {
         #[serde(rename = "@filename")]
         filename: String,
-        #[serde(rename = "@scale")]
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(rename = "@scale", skip_serializing_if = "Option::is_none")]
         scale: Option<Vec3>,
     },
 }
@@ -106,16 +105,15 @@ pub struct Texture {
 pub struct Material {
     #[serde(rename = "@name")]
     pub name: String,
-    pub color: Option<Color>,
-    #[serde(rename = "@texture")]
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<Color>,
+    #[serde(rename = "@texture", skip_serializing_if = "Option::is_none")]
     pub texture: Option<Texture>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Visual {
-    #[serde(rename = "@name")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@name", skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(default)]
     pub origin: Pose,
@@ -126,8 +124,7 @@ pub struct Visual {
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Collision {
-    #[serde(rename = "@name")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@name", skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(default)]
     pub origin: Pose,
@@ -238,9 +235,9 @@ pub struct JointLimit {
 pub struct Mimic {
     #[serde(rename = "@joint")]
     pub joint: String,
-    #[serde(rename = "@multiplier")]
+    #[serde(rename = "@multiplier", skip_serializing_if = "Option::is_none")]
     pub multiplier: Option<f64>,
-    #[serde(rename = "@offset")]
+    #[serde(rename = "@offset", skip_serializing_if = "Option::is_none")]
     pub offset: Option<f64>,
 }
 

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -289,12 +289,12 @@ pub struct Robot {
     #[serde(rename = "@name", default)]
     pub name: String,
 
-    #[serde(rename = "link", default)]
+    #[serde(rename = "link", default, skip_serializing_if = "Vec::is_empty")]
     pub links: Vec<Link>,
 
-    #[serde(rename = "joint", default)]
+    #[serde(rename = "joint", default, skip_serializing_if = "Vec::is_empty")]
     pub joints: Vec<Joint>,
 
-    #[serde(rename = "material", default)]
+    #[serde(rename = "material", default, skip_serializing_if = "Vec::is_empty")]
     pub materials: Vec<Material>,
 }

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -1,5 +1,7 @@
 use crate::deserialize::*;
 use crate::errors::*;
+use quick_xml::se::Serializer;
+use serde::Serialize;
 
 use std::path::Path;
 
@@ -73,7 +75,13 @@ pub fn read_from_string(string: &str) -> Result<Robot> {
 }
 
 pub fn write_to_string(robot: &Robot) -> Result<String> {
-    quick_xml::se::to_string(robot).map_err(|e| UrdfError::new(e.to_string()))
+    let mut buffer = String::new();
+    let mut s = Serializer::new(&mut buffer);
+    s.indent(' ', 2);
+    robot
+        .serialize(s)
+        .map_err(|e| UrdfError::new(e.to_string()))?;
+    Ok(buffer)
 }
 
 #[cfg(test)]

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -69,16 +69,11 @@ pub fn read_file<P: AsRef<Path>>(path: P) -> Result<Robot> {
 /// ```
 
 pub fn read_from_string(string: &str) -> Result<Robot> {
-    yaserde::de::from_str(string).map_err(UrdfError::new)
+    quick_xml::de::from_str(string).map_err(|e| UrdfError::new(e.to_string()))
 }
 
 pub fn write_to_string(robot: &Robot) -> Result<String> {
-    let conf = yaserde::ser::Config {
-        perform_indent: true,
-        write_document_declaration: false,
-        indent_string: None,
-    };
-    yaserde::ser::to_string_with_config(robot, &conf).map_err(UrdfError::new)
+    quick_xml::se::to_string(robot).map_err(|e| UrdfError::new(e.to_string()))
 }
 
 #[cfg(test)]
@@ -102,7 +97,7 @@ mod tests {
         assert_approx_eq!(rpy[1], -0.2);
         assert_approx_eq!(rpy[2], -0.3);
 
-        match &robot.links[0].visual[0].geometry {
+        match *robot.links[0].visual[0].geometry {
             Geometry::Box { size } => {
                 assert_approx_eq!(size[0], 1.0f64);
                 assert_approx_eq!(size[1], 2.0f64);
@@ -110,7 +105,7 @@ mod tests {
             }
             _ => panic!("geometry error"),
         }
-        match &robot.links[0].visual[1].geometry {
+        match *robot.links[0].visual[1].geometry {
             Geometry::Mesh {
                 ref filename,
                 scale,
@@ -120,7 +115,7 @@ mod tests {
             }
             _ => panic!("geometry error"),
         }
-        match &robot.links[0].visual[2].geometry {
+        match *robot.links[0].visual[2].geometry {
             Geometry::Mesh {
                 ref filename,
                 scale,
@@ -132,7 +127,7 @@ mod tests {
         }
 
         assert_eq!(robot.links[0].collision.len(), 1);
-        match &robot.links[0].collision[0].geometry {
+        match *robot.links[0].collision[0].geometry {
             Geometry::Cylinder { radius, length } => {
                 assert_approx_eq!(radius, 1.0);
                 assert_approx_eq!(length, 0.5);

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -97,6 +97,26 @@ mod tests {
         assert_approx_eq!(rpy[1], -0.2);
         assert_approx_eq!(rpy[2], -0.3);
 
+        // https://github.com/openrr/urdf-rs/issues/94
+        let xyz = &robot.links[0].visual[1].origin.xyz;
+        assert_approx_eq!(xyz[0], 0.1);
+        assert_approx_eq!(xyz[1], 0.2);
+        assert_approx_eq!(xyz[2], 0.3);
+        let rpy = &robot.links[0].visual[1].origin.rpy;
+        assert_approx_eq!(rpy[0], -0.1);
+        assert_approx_eq!(rpy[1], -0.2);
+        assert_approx_eq!(rpy[2], -0.3);
+
+        // https://github.com/openrr/urdf-rs/issues/95
+        assert!(robot.links[0].visual[0].material.is_some());
+        let mat = robot.links[0].visual[0].material.as_ref().unwrap();
+        assert_eq!(mat.name, "Cyan");
+        let rgba = mat.color.clone().unwrap().rgba;
+        assert_approx_eq!(rgba[0], 0.0);
+        assert_approx_eq!(rgba[1], 1.0);
+        assert_approx_eq!(rgba[2], 1.0);
+        assert_approx_eq!(rgba[3], 1.0);
+
         match *robot.links[0].visual[0].geometry {
             Geometry::Box { size } => {
                 assert_approx_eq!(size[0], 1.0f64);
@@ -188,10 +208,10 @@ mod tests {
                         </material>
                     </visual>
                     <visual>
-                        <origin xyz="0.1 0.2 0.3" rpy="-0.1 -0.2  -0.3" />
                         <geometry>
                             <mesh filename="aa.dae" />
                         </geometry>
+                        <origin xyz="0.1 0.2 0.3" rpy="-0.1 -0.2  -0.3" />
                     </visual>
                     <collision>
                         <origin xyz="0 0 0" rpy="0 0 0"/>


### PR DESCRIPTION
Opening for visibility, it "works for me" but I haven't had time yet to write additional extensive tests yet.

`quick-xml` uses `#[serde(rename)]` by prepending a `@` for attributes so it still allows specifying what should be serialize / deserialized into an attribute and what into a child element.
Preexisting unit tests work, I extended the test to cover #95 and #94 as well, with only one minor API breakage as denoted [here](https://github.com/openrr/urdf-rs/issues/96#issuecomment-1886250167).

We can remove a whole chunk of code for manual serialization / deserialization since `quick-xml` "just works" and doesn't need any of the workaround that either of the previous libraries needed (reordering elements for `serde-xml-rs` and serializing complex structs for `yaserde`).

I'd be happy to have some feedback on what to do with mandatory vs optional fields as denoted in https://github.com/openrr/urdf-rs/issues/95#issuecomment-1884423182, I can see arguments both ways so anything works really