### PR TITLE
Use std::sync::LazyLock instead of once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/openrr/urdf-rs"
 
 # Note: yaserde is public dependency.
 [dependencies]
-once_cell = "1"
 regex = "1.4.2"
 thiserror = "1.0.7"
 xml-rs = "0.8.3"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,11 +2,11 @@ use crate::deserialize::Robot;
 use crate::errors::*;
 use crate::funcs::*;
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 use std::borrow::Cow;
 use std::path::Path;
 use std::process::Command;
+use std::sync::LazyLock;
 
 pub fn convert_xacro_to_urdf_with_args<P>(filename: P, args: &[(String, String)]) -> Result<String>
 where
@@ -76,7 +76,7 @@ pub fn rospack_find(package: &str) -> Result<String> {
 // Note: We return Result here, although there is currently no branch that returns an error.
 // This is to avoid a breaking change when changing the error about package:// from panic to error.
 pub fn expand_package_path<'a>(filename: &'a str, base_dir: Option<&Path>) -> Result<Cow<'a, str>> {
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new("^package://(\\w+)/").unwrap());
+    static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new("^package://(\\w+)/").unwrap());
 
     Ok(if filename.starts_with("package://") {
         RE.replace(filename, |ma: &regex::Captures<'_>| {


### PR DESCRIPTION
std::sync::LazyLock has been stabilized in Rust 1.80.

The first commit is CI fix from #102.