### PR TITLE
Revert switching to yaserde, use quick-xml for serialization

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -1,5 +1,6 @@
 funcs
 inorder
+repr
 rgba
 rospack
 rosrun

--- a/.github/.cspell/rust-dependencies.txt
+++ b/.github/.cspell/rust-dependencies.txt
@@ -2,4 +2,3 @@
 // It is not intended for manual editing.
 
 thiserror
-yaserde

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/openrr/urdf-rs"
 # Note: serde is public dependency.
 [dependencies]
 regex = "1.4.2"
+RustyXML = "0.3.0"
 yaserde = "0.7.0"
 yaserde_derive = "0.7.0"
 thiserror = "1.0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,9 @@ repository = "https://github.com/openrr/urdf-rs"
 # Note: yaserde is public dependency.
 [dependencies]
 regex = "1.4.2"
+yaserde = "0.7.0"
+yaserde_derive = "0.7.0"
 thiserror = "1.0.7"
-xml-rs = "0.8.3"
-yaserde = "0.8"
-yaserde_derive = "0.8"
 
 [dev-dependencies]
 assert_approx_eq = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/openrr/urdf-rs"
 
 # Note: serde is public dependency.
 [dependencies]
+quick-xml = { version = "0.36", features = ["overlapped-lists", "serialize"] }
 regex = "1.4.2"
 RustyXML = "0.3.0"
 serde = { version = "1.0.118", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ repository = "https://github.com/openrr/urdf-rs"
 regex = "1.4.2"
 RustyXML = "0.3.0"
 serde = { version = "1.0.118", features = ["derive"] }
-yaserde = "0.7.0"
-yaserde_derive = "0.7.0"
 serde-xml-rs = "0.6.0"
 thiserror = "1.0.7"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ repository = "https://github.com/openrr/urdf-rs"
 regex = "1.4.2"
 thiserror = "1.0.7"
 xml-rs = "0.8.3"
-yaserde = { version = "0.9", features = ["yaserde_derive"] }
+yaserde = "0.8"
+yaserde_derive = "0.8"
 
 [dev-dependencies]
 assert_approx_eq = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ repository = "https://github.com/openrr/urdf-rs"
 [dependencies]
 regex = "1.4.2"
 RustyXML = "0.3.0"
+serde = { version = "1.0.118", features = ["derive"] }
 yaserde = "0.7.0"
 yaserde_derive = "0.7.0"
+serde-xml-rs = "0.6.0"
 thiserror = "1.0.7"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["robotics", "robot", "ros", "urdf"]
 categories = ["data-structures", "parsing"]
 repository = "https://github.com/openrr/urdf-rs"
 
-# Note: yaserde is public dependency.
+# Note: serde is public dependency.
 [dependencies]
 regex = "1.4.2"
 yaserde = "0.7.0"

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -80,6 +80,7 @@ impl YaSerialize for Geometry {
             .map_err(|e| e.to_string())?;
         match self {
             Geometry::Box { size } => {
+                dbg!(&format!("{:.1} {:.1} {:.1}", size[0], size[1], size[2]));
                 serializer
                     .write(
                         xml::writer::XmlEvent::start_element("box")

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,172 +1,107 @@
-use yaserde::{YaSerialize, YaDeserialize, Visitor};
-use yaserde::xml::namespace::Namespace;
-use yaserde::ser::Serializer;
-use yaserde::xml::attribute::OwnedAttribute;
-use yaserde::xml;
-use yaserde_derive::{YaSerialize, YaDeserialize};
-
-use std::io::{Read, Write};
+use serde::de::Visitor;
+use serde::{Deserialize, Serialize};
 
 use std::ops::{Deref, DerefMut};
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Mass {
-    #[yaserde(attribute)]
     pub value: f64,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Inertia {
-    #[yaserde(attribute)]
     pub ixx: f64,
-    #[yaserde(attribute)]
     pub ixy: f64,
-    #[yaserde(attribute)]
     pub ixz: f64,
-    #[yaserde(attribute)]
     pub iyy: f64,
-    #[yaserde(attribute)]
     pub iyz: f64,
-    #[yaserde(attribute)]
     pub izz: f64,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Inertial {
+    #[serde(default)]
     pub origin: Pose,
     pub mass: Mass,
     pub inertia: Inertia,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
-pub struct BoxGeometry {
-    #[yaserde(attribute)]
-    pub size: Vec3,
-}
-
-#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
-pub struct CylinderGeometry {
-    #[yaserde(attribute)]
-    pub radius: f64,
-    #[yaserde(attribute)]
-    pub length: f64,
-}
-
-#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
-pub struct CapsuleGeometry {
-    #[yaserde(attribute)]
-    pub radius: f64,
-    #[yaserde(attribute)]
-    pub length: f64,
-}
-
-#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
-pub struct SphereGeometry {
-    #[yaserde(attribute)]
-    pub radius: f64,
-}
-
-#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
-pub struct MeshGeometry {
-    #[yaserde(attribute)]
-    pub filename: String,
-    #[yaserde(attribute)]
-    pub scale: Option<Vec3>,
-}
-
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum Geometry {
-    Box(BoxGeometry),
-    Cylinder(CylinderGeometry),
-    Capsule(CapsuleGeometry),
-    Sphere(SphereGeometry),
-    Mesh(MeshGeometry),
+    Box {
+        size: Vec3,
+    },
+    Cylinder {
+        radius: f64,
+        length: f64,
+    },
+    Capsule {
+        radius: f64,
+        length: f64,
+    },
+    Sphere {
+        radius: f64,
+    },
+    Mesh {
+        filename: String,
+        #[serde(default)]
+        scale: Option<Vec3>,
+    },
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
-pub struct GeometrySerde {
-    #[yaserde(rename = "box")]
-    pub box_geometry: Option<BoxGeometry>,
-    #[yaserde(rename = "cylinder")]
-    pub cylinder: Option<CylinderGeometry>,
-    #[yaserde(rename = "capsule")]
-    pub capsule: Option<CapsuleGeometry>,
-    #[yaserde(rename = "sphere")]
-    pub sphere: Option<SphereGeometry>,
-    #[yaserde(rename = "mesh")]
-    pub mesh: Option<MeshGeometry>,
-}
-
-impl From<&GeometrySerde> for Geometry {
-    fn from(geom: &GeometrySerde) -> Geometry {
-        if let Some(b) = &geom.box_geometry {
-            Geometry::Box(b.clone())
-        } else if let Some(c) = &geom.cylinder {
-            Geometry::Cylinder(c.clone())
-        } else if let Some(c) = &geom.capsule {
-            Geometry::Capsule(c.clone())
-        } else if let Some(s) = &geom.sphere {
-            Geometry::Sphere(s.clone())
-        } else if let Some(m) = &geom.mesh {
-            Geometry::Mesh(m.clone())
-        } else {
-            panic!("Invalid geometry serde structure");
+impl Default for Geometry {
+    fn default() -> Geometry {
+        Geometry::Box {
+            size: Vec3::default(),
         }
     }
 }
 
-impl Default for GeometrySerde {
-    fn default() -> Self {
-        Self {
-            box_geometry: Some(BoxGeometry{size: Vec3::default()}),
-            cylinder: None,
-            capsule: None,
-            sphere: None,
-            mesh: None,
-        }
-    }
-}
-
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Color {
     pub rgba: Vec4,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Texture {
     pub filename: String,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Material {
-    #[yaserde(attribute)]
     pub name: String,
     pub color: Option<Color>,
     pub texture: Option<Texture>,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Visual {
     pub name: Option<String>,
+    #[serde(default)]
     pub origin: Pose,
-    pub geometry: GeometrySerde,
+    pub geometry: Geometry,
     pub material: Option<Material>,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Collision {
     pub name: Option<String>,
+    #[serde(default)]
     pub origin: Pose,
-    pub geometry: GeometrySerde,
+    pub geometry: Geometry,
 }
 
 /// Urdf Link element
 /// See <http://wiki.ros.org/urdf/XML/link> for more detail.
-#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Link {
-    #[yaserde(attribute)]
     pub name: String,
+    #[serde(default)]
     pub inertial: Inertial,
+    #[serde(default)]
     pub visual: Vec<Visual>,
+    #[serde(default)]
     pub collision: Vec<Collision>,
 }
 
@@ -187,49 +122,50 @@ impl DerefMut for Vec3 {
     }
 }
 
-impl YaSerialize for Vec3 {
-    fn serialize<W: Write>(&self, serializer: &mut yaserde::ser::Serializer<W>) -> Result<(), String>
+impl Serialize for Vec3 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
     {
-        // TODO(luca) cleanup this
-        println!("Serializing {:?}", self);
-        match serializer.write(xml::writer::XmlEvent::Characters(&format!("{} {} {}", self.0[0], self.0[1], self.0[2]))) {
-            Ok(()) => Ok(()),
-            Err(e) => Err(e.to_string()),
-        }
-    }
-
-    // TODO(luca) check this implementation
-    fn serialize_attributes(
-        &self, 
-        attributes: Vec<OwnedAttribute>, 
-        namespace: Namespace
-    ) -> Result<(Vec<OwnedAttribute>, Namespace), String> {
-        Ok((attributes, namespace))
+        serializer.serialize_str(&format!("{} {} {}", self.0[0], self.0[1], self.0[2]))
     }
 }
 
-impl YaDeserialize for Vec3 {
-    fn deserialize<R: Read>(deserializer: &mut yaserde::de::Deserializer<R>) -> Result<Self, String>
+impl<'de> Deserialize<'de> for Vec3 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
     {
-        deserializer.next_event();
-        if let Ok(xml::reader::XmlEvent::Characters(v)) = deserializer.peek() {
-            let split_results: Vec<_> = v
-                .split_whitespace()
-                .filter_map(|s| s.parse::<f64>().ok())
-                .collect();
-            if split_results.len() != 3 {
-                return Err(format!(
-                    "Wrong vector element count, expected 3 found {} for [{}]",
-                    split_results.len(),
-                    v
-                ));
-            }
-            let mut res = [0.0f64; 3];
-            res.copy_from_slice(&split_results);
-            return Ok(Vec3(res));
-        } else {
-            return Err("String of elements not found while parsing Vec3".to_string());
+        deserializer.deserialize_str(Vec3Visitor)
+    }
+}
+
+struct Vec3Visitor;
+impl<'de> Visitor<'de> for Vec3Visitor {
+    type Value = Vec3;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a string containing three floating point values separated by spaces")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        let split_results: Vec<_> = v
+            .split_whitespace()
+            .filter_map(|s| s.parse::<f64>().ok())
+            .collect();
+        if split_results.len() != 3 {
+            return Err(E::custom(format!(
+                "Wrong vector element count, expected 3 found {} for [{}]",
+                split_results.len(),
+                v
+            )));
         }
+        let mut res = [0.0f64; 3];
+        res.copy_from_slice(&split_results);
+        return Ok(Vec3(res));
     }
 }
 
@@ -250,144 +186,154 @@ impl DerefMut for Vec4 {
     }
 }
 
-impl YaSerialize for Vec4 {
-    fn serialize<W: Write>(&self, serializer: &mut yaserde::ser::Serializer<W>) -> Result<(), String>
+impl Serialize for Vec4 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
     {
-        // TODO(luca) cleanup this
-        match serializer.write(xml::writer::XmlEvent::Characters(&format!("{} {} {} {}", self.0[0], self.0[1], self.0[2], self.0[3]))) {
-            Ok(()) => Ok(()),
-            Err(e) => Err(e.to_string()),
-        }
-    }
-
-    // TODO(luca) check this implementation
-    fn serialize_attributes(
-        &self, 
-        attributes: Vec<OwnedAttribute>, 
-        namespace: Namespace
-    ) -> Result<(Vec<OwnedAttribute>, Namespace), String> {
-        Ok((attributes, namespace))
+        serializer.serialize_str(&format!(
+            "{} {} {} {}",
+            self.0[0], self.0[1], self.0[2], self.0[3]
+        ))
     }
 }
 
-impl YaDeserialize for Vec4 {
-    fn deserialize<R: Read>(deserializer: &mut yaserde::de::Deserializer<R>) -> Result<Self, String>
+impl<'de> Deserialize<'de> for Vec4 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
     {
-        deserializer.next_event();
-        if let xml::reader::XmlEvent::Characters(v) = deserializer.peek()? {
-            let split_results: Vec<_> = v
-                .split_whitespace()
-                .filter_map(|s| s.parse::<f64>().ok())
-                .collect();
-            if split_results.len() != 4 {
-                return Err(format!(
-                    "Wrong vector element count, expected 4 found {} for [{}]",
-                    split_results.len(),
-                    v
-                ));
-            }
-            let mut res = [0.0f64; 4];
-            res.copy_from_slice(&split_results);
-            return Ok(Vec4(res));
-        } else {
-            return Err("String of elements not found while parsing Vec3".to_string());
-        }
+        deserializer.deserialize_str(Vec4Visitor)
     }
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+struct Vec4Visitor;
+impl<'de> Visitor<'de> for Vec4Visitor {
+    type Value = Vec4;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a string containing four floating point values separated by spaces")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        let split_results: Vec<_> = v
+            .split_whitespace()
+            .filter_map(|s| s.parse::<f64>().ok())
+            .collect();
+        if split_results.len() != 4 {
+            return Err(E::custom(format!(
+                "Wrong vector element count, expected 4 found {} for [{}]",
+                split_results.len(),
+                v
+            )));
+        }
+        let mut res = [0.0f64; 4];
+        res.copy_from_slice(&split_results);
+        return Ok(Vec4(res));
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Axis {
-    #[yaserde(attribute)]
     pub xyz: Vec3,
 }
 
-#[derive(Debug, Default, YaDeserialize, YaSerialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct Pose {
-    #[yaserde(attribute)]
+    #[serde(default)]
     pub xyz: Vec3,
-    #[yaserde(attribute)]
+    #[serde(default)]
     pub rpy: Vec3,
 }
 
-#[derive(Debug, Default, YaDeserialize, YaSerialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct LinkName {
-    #[yaserde(attribute)]
     pub link: String,
 }
 
-// TODO(luca) see if we can avoid deriving default
-#[derive(Debug, Default, YaDeserialize, YaSerialize, Clone, PartialEq, Eq)]
-#[yaserde(rename_all = "snake_case")]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum JointType {
     Revolute,
     Continuous,
     Prismatic,
-    #[default]
     Fixed,
     Floating,
     Planar,
     Spherical,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct JointLimit {
+    #[serde(default)]
     pub lower: f64,
+    #[serde(default)]
     pub upper: f64,
     pub effort: f64,
     pub velocity: f64,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Mimic {
     pub joint: String,
     pub multiplier: Option<f64>,
     pub offset: Option<f64>,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct SafetyController {
+    #[serde(default)]
     pub soft_lower_limit: f64,
+    #[serde(default)]
     pub soft_upper_limit: f64,
+    #[serde(default)]
     pub k_position: f64,
     pub k_velocity: f64,
 }
 
 /// Urdf Joint element
 /// See <http://wiki.ros.org/urdf/XML/joint> for more detail.
-#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Joint {
-    #[yaserde(attribute)]
     pub name: String,
-    #[yaserde(rename = "type")]
+    #[serde(rename = "type")]
     pub joint_type: JointType,
+    #[serde(default)]
     pub origin: Pose,
     pub parent: LinkName,
     pub child: LinkName,
+    #[serde(default)]
     pub axis: Axis,
+    #[serde(default)]
     pub limit: JointLimit,
     pub dynamics: Option<Dynamics>,
     pub mimic: Option<Mimic>,
     pub safety_controller: Option<SafetyController>,
 }
 
-#[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Dynamics {
+    #[serde(default)]
     pub damping: f64,
+    #[serde(default)]
     pub friction: f64,
 }
 
 /// Top level struct to access urdf.
-#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Robot {
-    #[yaserde(attribute)]
+    #[serde(default)]
     pub name: String,
 
-    #[yaserde(rename = "link")]
+    #[serde(rename = "link", default)]
     pub links: Vec<Link>,
 
-    #[yaserde(rename = "joint")]
+    #[serde(rename = "joint", default)]
     pub joints: Vec<Joint>,
 
-    #[yaserde(rename = "material")]
+    #[serde(rename = "material", default)]
     pub materials: Vec<Material>,
 }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,5 +1,6 @@
-use xml::attribute::OwnedAttribute;
-use xml::namespace::Namespace;
+use yaserde::xml;
+use yaserde::xml::attribute::OwnedAttribute;
+use yaserde::xml::namespace::Namespace;
 use yaserde::{YaDeserialize, YaSerialize};
 use yaserde_derive::{YaDeserialize, YaSerialize};
 
@@ -502,7 +503,7 @@ pub struct Dynamics {
 
 /// Top level struct to access urdf.
 #[derive(Debug, YaDeserialize, YaSerialize, Clone)]
-#[yaserde(rename = "robot", namespace = "http://www.ros.org")]
+#[yaserde(rename = "robot")]
 pub struct Robot {
     #[yaserde(attribute)]
     pub name: String,

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -5,16 +5,23 @@ use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Mass {
+    #[serde(rename(serialize = "@value"))]
     pub value: f64,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Inertia {
+    #[serde(rename(serialize = "@ixx"))]
     pub ixx: f64,
+    #[serde(rename(serialize = "@ixy"))]
     pub ixy: f64,
+    #[serde(rename(serialize = "@ixz"))]
     pub ixz: f64,
+    #[serde(rename(serialize = "@iyy"))]
     pub iyy: f64,
+    #[serde(rename(serialize = "@iyz"))]
     pub iyz: f64,
+    #[serde(rename(serialize = "@izz"))]
     pub izz: f64,
 }
 
@@ -30,72 +37,128 @@ pub struct Inertial {
 #[serde(rename_all = "snake_case")]
 pub enum Geometry {
     Box {
+        #[serde(rename(serialize = "@size"))]
         size: Vec3,
     },
     Cylinder {
+        #[serde(rename(serialize = "@radius"))]
         radius: f64,
+        #[serde(rename(serialize = "@length"))]
         length: f64,
     },
     Capsule {
+        #[serde(rename(serialize = "@radius"))]
         radius: f64,
+        #[serde(rename(serialize = "@length"))]
         length: f64,
     },
     Sphere {
+        #[serde(rename(serialize = "@radius"))]
         radius: f64,
     },
     Mesh {
+        #[serde(rename(serialize = "@filename"))]
         filename: String,
-        #[serde(default)]
+        #[serde(rename(serialize = "@scale"), skip_serializing_if = "Option::is_none")]
         scale: Option<Vec3>,
     },
 }
 
 impl Default for Geometry {
-    fn default() -> Geometry {
-        Geometry::Box {
+    fn default() -> Self {
+        Self::Box {
             size: Vec3::default(),
         }
     }
 }
 
+#[derive(Debug, Default, Serialize, Clone)]
+pub struct GeometryTag {
+    #[serde(rename(serialize = "$value"))]
+    pub value: Geometry,
+}
+
+impl From<Geometry> for GeometryTag {
+    fn from(geom: Geometry) -> Self {
+        Self { value: geom }
+    }
+}
+
+impl Deref for GeometryTag {
+    type Target = Geometry;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl DerefMut for GeometryTag {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+impl<'de> Deserialize<'de> for GeometryTag {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self {
+            value: Geometry::deserialize(deserializer)?,
+        })
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Color {
+    #[serde(rename(serialize = "@rgba"))]
     pub rgba: Vec4,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Texture {
+    #[serde(rename(serialize = "@filename"))]
     pub filename: String,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Material {
+    #[serde(rename(serialize = "@name"))]
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<Color>,
+    #[serde(
+        rename(serialize = "@texture"),
+        skip_serializing_if = "Option::is_none"
+    )]
     pub texture: Option<Texture>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Visual {
+    #[serde(rename(serialize = "@name"), skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(default)]
     pub origin: Pose,
-    pub geometry: Geometry,
+    pub geometry: GeometryTag,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub material: Option<Material>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Collision {
+    #[serde(rename(serialize = "@name"), skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(default)]
     pub origin: Pose,
-    pub geometry: Geometry,
+    pub geometry: GeometryTag,
 }
 
 /// Urdf Link element
 /// See <http://wiki.ros.org/urdf/XML/link> for more detail.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Link {
+    #[serde(rename(serialize = "@name"))]
     pub name: String,
     #[serde(default)]
     pub inertial: Inertial,
@@ -105,29 +168,20 @@ pub struct Link {
     pub collision: Vec<Collision>,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct Vec3(pub [f64; 3]);
+#[derive(Debug, Serialize, Default, Clone, Copy, PartialEq)]
+pub struct Vec3(#[serde(rename(serialize = "$text"))] pub [f64; 3]);
 
 impl Deref for Vec3 {
     type Target = [f64; 3];
 
     fn deref(&self) -> &Self::Target {
-        return &self.0;
+        &self.0
     }
 }
 
 impl DerefMut for Vec3 {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        return &mut self.0;
-    }
-}
-
-impl Serialize for Vec3 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&format!("{} {} {}", self.0[0], self.0[1], self.0[2]))
+        &mut self.0
     }
 }
 
@@ -141,7 +195,7 @@ impl<'de> Deserialize<'de> for Vec3 {
 }
 
 struct Vec3Visitor;
-impl<'de> Visitor<'de> for Vec3Visitor {
+impl Visitor<'_> for Vec3Visitor {
     type Value = Vec3;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -165,36 +219,24 @@ impl<'de> Visitor<'de> for Vec3Visitor {
         }
         let mut res = [0.0f64; 3];
         res.copy_from_slice(&split_results);
-        return Ok(Vec3(res));
+        Ok(Vec3(res))
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct Vec4(pub [f64; 4]);
+#[derive(Debug, Serialize, Default, Clone, Copy, PartialEq)]
+pub struct Vec4(#[serde(rename(serialize = "$text"))] pub [f64; 4]);
 
 impl Deref for Vec4 {
     type Target = [f64; 4];
 
     fn deref(&self) -> &Self::Target {
-        return &self.0;
+        &self.0
     }
 }
 
 impl DerefMut for Vec4 {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        return &mut self.0;
-    }
-}
-
-impl Serialize for Vec4 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&format!(
-            "{} {} {} {}",
-            self.0[0], self.0[1], self.0[2], self.0[3]
-        ))
+        &mut self.0
     }
 }
 
@@ -208,7 +250,7 @@ impl<'de> Deserialize<'de> for Vec4 {
 }
 
 struct Vec4Visitor;
-impl<'de> Visitor<'de> for Vec4Visitor {
+impl Visitor<'_> for Vec4Visitor {
     type Value = Vec4;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -232,25 +274,35 @@ impl<'de> Visitor<'de> for Vec4Visitor {
         }
         let mut res = [0.0f64; 4];
         res.copy_from_slice(&split_results);
-        return Ok(Vec4(res));
+        Ok(Vec4(res))
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Axis {
+    #[serde(rename(serialize = "@xyz"))]
     pub xyz: Vec3,
+}
+
+impl Default for Axis {
+    fn default() -> Axis {
+        Axis {
+            xyz: Vec3([1.0, 0.0, 0.0]),
+        }
+    }
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct Pose {
-    #[serde(default)]
+    #[serde(rename(serialize = "@xyz"), default)]
     pub xyz: Vec3,
-    #[serde(default)]
+    #[serde(rename(serialize = "@rpy"), default)]
     pub rpy: Vec3,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct LinkName {
+    #[serde(rename(serialize = "@link"))]
     pub link: String,
 }
 
@@ -268,29 +320,38 @@ pub enum JointType {
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct JointLimit {
-    #[serde(default)]
+    #[serde(rename(serialize = "@lower"), default)]
     pub lower: f64,
-    #[serde(default)]
+    #[serde(rename(serialize = "@upper"), default)]
     pub upper: f64,
+    #[serde(rename(serialize = "@effort"), default)]
     pub effort: f64,
+    #[serde(rename(serialize = "@velocity"))]
     pub velocity: f64,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Mimic {
+    #[serde(rename(serialize = "@joint"))]
     pub joint: String,
+    #[serde(
+        rename(serialize = "@multiplier"),
+        skip_serializing_if = "Option::is_none"
+    )]
     pub multiplier: Option<f64>,
+    #[serde(rename(serialize = "@offset"), skip_serializing_if = "Option::is_none")]
     pub offset: Option<f64>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct SafetyController {
-    #[serde(default)]
+    #[serde(rename(serialize = "@soft_lower_limit"), default)]
     pub soft_lower_limit: f64,
-    #[serde(default)]
+    #[serde(rename(serialize = "@soft_upper_limit"), default)]
     pub soft_upper_limit: f64,
-    #[serde(default)]
+    #[serde(rename(serialize = "@k_position"), default)]
     pub k_position: f64,
+    #[serde(rename(serialize = "@k_velocity"))]
     pub k_velocity: f64,
 }
 
@@ -298,8 +359,9 @@ pub struct SafetyController {
 /// See <http://wiki.ros.org/urdf/XML/joint> for more detail.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Joint {
+    #[serde(rename(serialize = "@name"))]
     pub name: String,
-    #[serde(rename = "type")]
+    #[serde(rename(deserialize = "type", serialize = "@type"))]
     pub joint_type: JointType,
     #[serde(default)]
     pub origin: Pose,
@@ -309,31 +371,35 @@ pub struct Joint {
     pub axis: Axis,
     #[serde(default)]
     pub limit: JointLimit,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dynamics: Option<Dynamics>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mimic: Option<Mimic>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub safety_controller: Option<SafetyController>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Dynamics {
-    #[serde(default)]
+    #[serde(rename(serialize = "@damping"), default)]
     pub damping: f64,
-    #[serde(default)]
+    #[serde(rename(serialize = "@friction"), default)]
     pub friction: f64,
 }
 
 /// Top level struct to access urdf.
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename = "robot")]
 pub struct Robot {
-    #[serde(default)]
+    #[serde(rename(serialize = "@name"), default)]
     pub name: String,
 
-    #[serde(rename = "link", default)]
+    #[serde(rename = "link", default, skip_serializing_if = "Vec::is_empty")]
     pub links: Vec<Link>,
 
-    #[serde(rename = "joint", default)]
+    #[serde(rename = "joint", default, skip_serializing_if = "Vec::is_empty")]
     pub joints: Vec<Joint>,
 
-    #[serde(rename = "material", default)]
+    #[serde(rename = "material", default, skip_serializing_if = "Vec::is_empty")]
     pub materials: Vec<Material>,
 }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -6,7 +6,6 @@ use yaserde_derive::{YaDeserialize, YaSerialize};
 
 use std::io::{Read, Write};
 
-use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
@@ -38,209 +37,89 @@ pub struct Inertial {
     pub inertia: Inertia,
 }
 
-// TODO(anyone) Derive YaSerialize and YaSerialize and remove custom impl once upstream bug is fixed
-// https://github.com/media-io/yaserde/issues/129
+#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+pub struct BoxGeometry {
+    #[yaserde(attribute)]
+    pub size: Vec3,
+}
+
+#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+pub struct CylinderGeometry {
+    #[yaserde(attribute)]
+    pub radius: f64,
+    #[yaserde(attribute)]
+    pub length: f64,
+}
+
+#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+pub struct CapsuleGeometry {
+    #[yaserde(attribute)]
+    pub radius: f64,
+    #[yaserde(attribute)]
+    pub length: f64,
+}
+
+#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+pub struct SphereGeometry {
+    #[yaserde(attribute)]
+    pub radius: f64,
+}
+
+#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+pub struct MeshGeometry {
+    #[yaserde(attribute)]
+    pub filename: String,
+    #[yaserde(attribute)]
+    pub scale: Option<Vec3>,
+}
+
 #[derive(Debug, Clone)]
 pub enum Geometry {
-    Box {
-        size: Vec3,
-    },
-    Cylinder {
-        radius: f64,
-        length: f64,
-    },
-    Capsule {
-        radius: f64,
-        length: f64,
-    },
-    Sphere {
-        radius: f64,
-    },
-    Mesh {
-        filename: String,
-        scale: Option<Vec3>,
-    },
+    Box(BoxGeometry),
+    Cylinder(CylinderGeometry),
+    Capsule(CapsuleGeometry),
+    Sphere(SphereGeometry),
+    Mesh(MeshGeometry),
 }
 
-impl Default for Geometry {
-    fn default() -> Self {
-        Self::Box {
-            size: Vec3::default(),
-        }
-    }
+#[derive(Debug, YaDeserialize, YaSerialize, Clone)]
+pub struct GeometrySerde {
+    #[yaserde(rename = "box")]
+    box_geometry: Option<BoxGeometry>,
+    cylinder: Option<CylinderGeometry>,
+    capsule: Option<CapsuleGeometry>,
+    sphere: Option<SphereGeometry>,
+    mesh: Option<MeshGeometry>,
 }
 
-impl YaSerialize for Geometry {
-    fn serialize<W: Write>(
-        &self,
-        serializer: &mut yaserde::ser::Serializer<W>,
-    ) -> Result<(), String> {
-        serializer
-            .write(xml::writer::XmlEvent::start_element("geometry"))
-            .map_err(|e| e.to_string())?;
-        match self {
-            Geometry::Box { size } => {
-                dbg!(&format!("{:.1} {:.1} {:.1}", size[0], size[1], size[2]));
-                serializer
-                    .write(
-                        xml::writer::XmlEvent::start_element("box")
-                            .attr("size", &format!("{} {} {}", size[0], size[1], size[2])),
-                    )
-                    .map_err(|e| e.to_string())?;
-            }
-            Geometry::Cylinder { radius, length } => {
-                serializer
-                    .write(
-                        xml::writer::XmlEvent::start_element("cylinder")
-                            .attr("radius", &radius.to_string())
-                            .attr("length", &length.to_string()),
-                    )
-                    .map_err(|e| e.to_string())?;
-            }
-            Geometry::Capsule { radius, length } => {
-                serializer
-                    .write(
-                        xml::writer::XmlEvent::start_element("capsule")
-                            .attr("radius", &radius.to_string())
-                            .attr("length", &length.to_string()),
-                    )
-                    .map_err(|e| e.to_string())?;
-            }
-            Geometry::Sphere { radius } => {
-                serializer
-                    .write(
-                        xml::writer::XmlEvent::start_element("sphere")
-                            .attr("radius", &radius.to_string()),
-                    )
-                    .map_err(|e| e.to_string())?;
-            }
-            Geometry::Mesh { filename, scale } => {
-                let builder =
-                    xml::writer::XmlEvent::start_element("mesh").attr("filename", filename);
-                if let Some(scale) = scale {
-                    serializer
-                        .write(
-                            builder
-                                .attr("scale", &format!("{} {} {}", scale[0], scale[1], scale[2])),
-                        )
-                        .map_err(|e| e.to_string())?;
-                } else {
-                    serializer.write(builder).map_err(|e| e.to_string())?;
-                }
-            }
-        }
-        serializer
-            .write(xml::writer::XmlEvent::end_element())
-            .map_err(|e| e.to_string())?;
-        serializer
-            .write(xml::writer::XmlEvent::end_element())
-            .map_err(|e| e.to_string())?;
-        Ok(())
-    }
-
-    fn serialize_attributes(
-        &self,
-        attributes: Vec<OwnedAttribute>,
-        namespace: Namespace,
-    ) -> Result<(Vec<OwnedAttribute>, Namespace), String> {
-        Ok((attributes, namespace))
-    }
-}
-
-impl YaDeserialize for Geometry {
-    fn deserialize<R: Read>(
-        deserializer: &mut yaserde::de::Deserializer<R>,
-    ) -> Result<Self, String> {
-        deserializer.next_event()?;
-        if let Ok(xml::reader::XmlEvent::StartElement {
-            name,
-            attributes,
-            namespace: _,
-        }) = deserializer.peek()
-        {
-            let attributes: HashMap<_, _> = attributes
-                .iter()
-                .map(|attr| (attr.name.local_name.clone(), attr.value.clone()))
-                .collect();
-            if name.local_name == "box" {
-                if let Some(v) = attributes.get("size") {
-                    let split_results: Vec<_> = v
-                        .split_whitespace()
-                        .filter_map(|s| s.parse::<f64>().ok())
-                        .collect();
-                    if split_results.len() != 3 {
-                        return Err(format!(
-                            "Wrong vector element count, expected 3 found {} for [{}]",
-                            split_results.len(),
-                            v
-                        ));
-                    }
-                    let mut res = [0.0f64; 3];
-                    res.copy_from_slice(&split_results);
-                    Ok(Self::Box { size: Vec3(res) })
-                } else {
-                    Err(format!(
-                        "Failed parsing attributes for box {:?}",
-                        attributes
-                    ))
-                }
-            } else if name.local_name == "cylinder" {
-                if let (Some(length), Some(radius)) = (
-                    attributes.get("length").and_then(|a| a.parse::<f64>().ok()),
-                    attributes.get("radius").and_then(|a| a.parse::<f64>().ok()),
-                ) {
-                    Ok(Self::Cylinder { length, radius })
-                } else {
-                    Err("Failed parsing radius and size for cylinder geometry".to_string())
-                }
-            } else if name.local_name == "capsule" {
-                if let (Some(length), Some(radius)) = (
-                    attributes.get("length").and_then(|a| a.parse::<f64>().ok()),
-                    attributes.get("radius").and_then(|a| a.parse::<f64>().ok()),
-                ) {
-                    Ok(Self::Capsule { length, radius })
-                } else {
-                    Err("Failed parsing radius and size for capsule geometry".to_string())
-                }
-            } else if name.local_name == "sphere" {
-                if let Some(radius) = attributes.get("radius").and_then(|a| a.parse::<f64>().ok()) {
-                    Ok(Self::Sphere { radius })
-                } else {
-                    Err("Failed parsing radius and size for sphere geometry".to_string())
-                }
-            } else if name.local_name == "mesh" {
-                if let Some(filename) = attributes
-                    .get("filename")
-                    .and_then(|a| a.parse::<String>().ok())
-                {
-                    let scale = if let Some(v) = attributes.get("scale") {
-                        // TODO(luca) remove duplication with all vec parsing code
-                        let split_results: Vec<_> = v
-                            .split_whitespace()
-                            .filter_map(|s| s.parse::<f64>().ok())
-                            .collect();
-                        if split_results.len() != 3 {
-                            return Err(format!(
-                                "Wrong vector element count, expected 3 found {} for [{}]",
-                                split_results.len(),
-                                v
-                            ));
-                        }
-                        let mut res = [0.0f64; 3];
-                        res.copy_from_slice(&split_results);
-                        Some(Vec3(res))
-                    } else {
-                        None
-                    };
-                    Ok(Self::Mesh { filename, scale })
-                } else {
-                    Err("Error parsing filename for mesh".to_string())
-                }
-            } else {
-                Err(format!("Invalid geometry name [{}] found", name.local_name))
-            }
+impl From<&GeometrySerde> for Geometry {
+    fn from(geom: &GeometrySerde) -> Geometry {
+        if let Some(b) = &geom.box_geometry {
+            Geometry::Box(b.clone())
+        } else if let Some(c) = &geom.cylinder {
+            Geometry::Cylinder(c.clone())
+        } else if let Some(c) = &geom.capsule {
+            Geometry::Capsule(c.clone())
+        } else if let Some(s) = &geom.sphere {
+            Geometry::Sphere(s.clone())
+        } else if let Some(m) = &geom.mesh {
+            Geometry::Mesh(m.clone())
         } else {
-            Err("Elements not found while parsing Geometry".to_string())
+            panic!("Invalid geometry serde structure");
+        }
+    }
+}
+
+impl Default for GeometrySerde {
+    fn default() -> Self {
+        Self {
+            box_geometry: Some(BoxGeometry {
+                size: Vec3::default(),
+            }),
+            cylinder: None,
+            capsule: None,
+            sphere: None,
+            mesh: None,
         }
     }
 }
@@ -272,7 +151,7 @@ pub struct Visual {
     #[yaserde(attribute)]
     pub name: Option<String>,
     pub origin: Pose,
-    pub geometry: Geometry,
+    pub geometry: GeometrySerde,
     pub material: Option<Material>,
 }
 
@@ -281,7 +160,7 @@ pub struct Collision {
     #[yaserde(attribute)]
     pub name: Option<String>,
     pub origin: Pose,
-    pub geometry: Geometry,
+    pub geometry: GeometrySerde,
 }
 
 /// Urdf Link element

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -325,21 +325,15 @@ pub struct LinkName {
 }
 
 #[derive(Debug, Default, YaDeserialize, YaSerialize, Clone, PartialEq, Eq)]
+#[yaserde(rename_all = "snake_case")]
 pub enum JointType {
-    #[yaserde(rename = "revolute")]
     Revolute,
-    #[yaserde(rename = "continuous")]
     Continuous,
-    #[yaserde(rename = "prismatic")]
     Prismatic,
     #[default]
-    #[yaserde(rename = "fixed")]
     Fixed,
-    #[yaserde(rename = "floating")]
     Floating,
-    #[yaserde(rename = "planar")]
     Planar,
-    #[yaserde(rename = "spherical")]
     Spherical,
 }
 
@@ -372,7 +366,7 @@ pub struct SafetyController {
 pub struct Joint {
     #[yaserde(attribute)]
     pub name: String,
-    #[yaserde(attribute, rename = "type")]
+    #[yaserde(rename = "type")]
     pub joint_type: JointType,
     pub origin: Pose,
     pub parent: LinkName,

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -398,7 +398,7 @@ impl YaDeserialize for Vec4 {
             res.copy_from_slice(&split_results);
             Ok(Vec4(res))
         } else {
-            Err("String of elements not found while parsing Vec4".to_string())
+            Err("String of elements not found while parsing Vec3".to_string())
         }
     }
 }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,6 +1,7 @@
 use xml::attribute::OwnedAttribute;
 use xml::namespace::Namespace;
 use yaserde::{YaDeserialize, YaSerialize};
+use yaserde_derive::{YaDeserialize, YaSerialize};
 
 use std::io::{Read, Write};
 

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,8 +1,8 @@
-use yaserde::xml;
-use yaserde::xml::attribute::OwnedAttribute;
+use yaserde::{YaSerialize, YaDeserialize};
 use yaserde::xml::namespace::Namespace;
-use yaserde::{YaDeserialize, YaSerialize};
-use yaserde_derive::{YaDeserialize, YaSerialize};
+use yaserde::xml::attribute::OwnedAttribute;
+use yaserde::xml;
+use yaserde_derive::{YaSerialize, YaDeserialize};
 
 use std::io::{Read, Write};
 
@@ -113,9 +113,7 @@ impl From<&GeometrySerde> for Geometry {
 impl Default for GeometrySerde {
     fn default() -> Self {
         Self {
-            box_geometry: Some(BoxGeometry {
-                size: Vec3::default(),
-            }),
+            box_geometry: Some(BoxGeometry{size: Vec3::default()}),
             cylinder: None,
             capsule: None,
             sphere: None,
@@ -192,31 +190,23 @@ impl DerefMut for Vec3 {
 }
 
 impl YaSerialize for Vec3 {
-    fn serialize<W: Write>(
-        &self,
-        serializer: &mut yaserde::ser::Serializer<W>,
-    ) -> Result<(), String> {
-        serializer
-            .write(xml::writer::XmlEvent::Characters(&format!(
-                "{} {} {}",
-                self.0[0], self.0[1], self.0[2]
-            )))
-            .map_err(|e| e.to_string())
+    fn serialize<W: Write>(&self, serializer: &mut yaserde::ser::Serializer<W>) -> Result<(), String>
+    {
+        serializer.write(xml::writer::XmlEvent::Characters(&format!("{} {} {}", self.0[0], self.0[1], self.0[2]))).map_err(|e| e.to_string())
     }
 
     fn serialize_attributes(
-        &self,
-        attributes: Vec<OwnedAttribute>,
-        namespace: Namespace,
+        &self, 
+        attributes: Vec<OwnedAttribute>, 
+        namespace: Namespace
     ) -> Result<(Vec<OwnedAttribute>, Namespace), String> {
         Ok((attributes, namespace))
     }
 }
 
 impl YaDeserialize for Vec3 {
-    fn deserialize<R: Read>(
-        deserializer: &mut yaserde::de::Deserializer<R>,
-    ) -> Result<Self, String> {
+    fn deserialize<R: Read>(deserializer: &mut yaserde::de::Deserializer<R>) -> Result<Self, String>
+    {
         deserializer.next_event()?;
         if let Ok(xml::reader::XmlEvent::Characters(v)) = deserializer.peek() {
             let split_results: Vec<_> = v
@@ -257,31 +247,23 @@ impl DerefMut for Vec4 {
 }
 
 impl YaSerialize for Vec4 {
-    fn serialize<W: Write>(
-        &self,
-        serializer: &mut yaserde::ser::Serializer<W>,
-    ) -> Result<(), String> {
-        serializer
-            .write(xml::writer::XmlEvent::Characters(&format!(
-                "{} {} {} {}",
-                self.0[0], self.0[1], self.0[2], self.0[3]
-            )))
-            .map_err(|e| e.to_string())
+    fn serialize<W: Write>(&self, serializer: &mut yaserde::ser::Serializer<W>) -> Result<(), String>
+    {
+        serializer.write(xml::writer::XmlEvent::Characters(&format!("{} {} {} {}", self.0[0], self.0[1], self.0[2], self.0[3]))).map_err(|e| e.to_string())
     }
 
     fn serialize_attributes(
-        &self,
-        attributes: Vec<OwnedAttribute>,
-        namespace: Namespace,
+        &self, 
+        attributes: Vec<OwnedAttribute>, 
+        namespace: Namespace
     ) -> Result<(Vec<OwnedAttribute>, Namespace), String> {
         Ok((attributes, namespace))
     }
 }
 
 impl YaDeserialize for Vec4 {
-    fn deserialize<R: Read>(
-        deserializer: &mut yaserde::de::Deserializer<R>,
-    ) -> Result<Self, String> {
+    fn deserialize<R: Read>(deserializer: &mut yaserde::de::Deserializer<R>) -> Result<Self, String>
+    {
         deserializer.next_event()?;
         if let xml::reader::XmlEvent::Characters(v) = deserializer.peek()? {
             let split_results: Vec<_> = v

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -181,13 +181,13 @@ impl Deref for Vec3 {
     type Target = [f64; 3];
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        return &self.0;
     }
 }
 
 impl DerefMut for Vec3 {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        return &mut self.0;
     }
 }
 
@@ -232,9 +232,9 @@ impl YaDeserialize for Vec3 {
             }
             let mut res = [0.0f64; 3];
             res.copy_from_slice(&split_results);
-            Ok(Vec3(res))
+            return Ok(Vec3(res));
         } else {
-            Err("String of elements not found while parsing Vec3".to_string())
+            return Err("String of elements not found while parsing Vec3".to_string());
         }
     }
 }
@@ -246,13 +246,13 @@ impl Deref for Vec4 {
     type Target = [f64; 4];
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        return &self.0;
     }
 }
 
 impl DerefMut for Vec4 {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        return &mut self.0;
     }
 }
 
@@ -297,9 +297,9 @@ impl YaDeserialize for Vec4 {
             }
             let mut res = [0.0f64; 4];
             res.copy_from_slice(&split_results);
-            Ok(Vec4(res))
+            return Ok(Vec4(res));
         } else {
-            Err("String of elements not found while parsing Vec3".to_string())
+            return Err("String of elements not found while parsing Vec3".to_string());
         }
     }
 }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -455,23 +455,16 @@ pub struct JointLimit {
 
 #[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Mimic {
-    #[yaserde(attribute)]
     pub joint: String,
-    #[yaserde(attribute)]
     pub multiplier: Option<f64>,
-    #[yaserde(attribute)]
     pub offset: Option<f64>,
 }
 
 #[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct SafetyController {
-    #[yaserde(attribute)]
     pub soft_lower_limit: f64,
-    #[yaserde(attribute)]
     pub soft_upper_limit: f64,
-    #[yaserde(attribute)]
     pub k_position: f64,
-    #[yaserde(attribute)]
     pub k_velocity: f64,
 }
 
@@ -495,9 +488,7 @@ pub struct Joint {
 
 #[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct Dynamics {
-    #[yaserde(attribute)]
     pub damping: f64,
-    #[yaserde(attribute)]
     pub friction: f64,
 }
 

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -310,18 +310,19 @@ pub struct Pose {
     pub rpy: Vec3,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct LinkName {
     #[serde(rename(serialize = "@link"))]
     pub link: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum JointType {
     Revolute,
     Continuous,
     Prismatic,
+    #[default]
     Fixed,
     Floating,
     Planar,

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -443,13 +443,9 @@ pub enum JointType {
 
 #[derive(Debug, YaDeserialize, YaSerialize, Default, Clone)]
 pub struct JointLimit {
-    #[yaserde(attribute)]
     pub lower: f64,
-    #[yaserde(attribute)]
     pub upper: f64,
-    #[yaserde(attribute)]
     pub effort: f64,
-    #[yaserde(attribute)]
     pub velocity: f64,
 }
 

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -503,7 +503,6 @@ pub struct Dynamics {
 
 /// Top level struct to access urdf.
 #[derive(Debug, YaDeserialize, YaSerialize, Clone)]
-#[yaserde(rename = "robot")]
 pub struct Robot {
     #[yaserde(attribute)]
     pub name: String,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,6 +17,8 @@ pub(crate) enum ErrorKind {
     #[error(transparent)]
     File(#[from] std::io::Error),
     #[error(transparent)]
+    Xml(#[from] serde_xml_rs::Error),
+    #[error(transparent)]
     RustyXml(#[from] xml::BuilderError),
     #[error("command error {}\n--- stdout\n{}\n--- stderr\n{}", .msg, .stdout, .stderr)]
     Command {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,6 +20,8 @@ pub(crate) enum ErrorKind {
     Xml(#[from] serde_xml_rs::Error),
     #[error(transparent)]
     RustyXml(#[from] xml::BuilderError),
+    #[error(transparent)]
+    QuickXml(#[from] quick_xml::DeError),
     #[error("command error {}\n--- stdout\n{}\n--- stderr\n{}", .msg, .stdout, .stderr)]
     Command {
         msg: String,
@@ -45,6 +47,12 @@ impl From<std::io::Error> for UrdfError {
 impl From<&str> for UrdfError {
     fn from(err: &str) -> UrdfError {
         ErrorKind::Other(err.to_owned()).into()
+    }
+}
+
+impl From<String> for UrdfError {
+    fn from(err: String) -> UrdfError {
+        ErrorKind::Other(err).into()
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,19 +48,6 @@ impl From<&str> for UrdfError {
     }
 }
 
-impl From<String> for UrdfError {
-    fn from(err: String) -> UrdfError {
-        ErrorKind::Other(err).into()
-    }
-}
-
-// TODO(luca) why do we need this?
-impl From<String> for ErrorKind {
-    fn from(err: String) -> ErrorKind {
-        ErrorKind::Other(err)
-    }
-}
-
 impl From<std::string::FromUtf8Error> for UrdfError {
     fn from(err: std::string::FromUtf8Error) -> UrdfError {
         ErrorKind::Other(err.to_string()).into()

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,8 @@ pub struct UrdfError(#[from] ErrorKind);
 pub(crate) enum ErrorKind {
     #[error(transparent)]
     File(#[from] std::io::Error),
+    #[error(transparent)]
+    RustyXml(#[from] xml::BuilderError),
     #[error("command error {}\n--- stdout\n{}\n--- stderr\n{}", .msg, .stdout, .stderr)]
     Command {
         msg: String,

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -154,10 +154,6 @@ mod tests {
         assert_eq!(robot.joints[0].parent.link, "shoulder1");
         assert_eq!(robot.joints[0].child.link, "elbow1");
         assert_eq!(robot.joints[0].joint_type, JointType::Revolute);
-        assert_approx_eq!(robot.joints[0].limit.upper, 1.0);
-        assert_approx_eq!(robot.joints[0].limit.lower, -1.0);
-        assert_approx_eq!(robot.joints[0].limit.effort, 0.0);
-        assert_approx_eq!(robot.joints[0].limit.velocity, 1.0);
         let xyz = &robot.joints[0].axis.xyz;
         assert_approx_eq!(xyz[0], 0.0f64);
         assert_approx_eq!(xyz[1], 1.0f64);

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -145,7 +145,7 @@ mod tests {
         assert_approx_eq!(rpy[1], -0.2);
         assert_approx_eq!(rpy[2], -0.3);
 
-        match (&robot.links[0].visual[0].geometry).into() {
+        match Geometry::from(&robot.links[0].visual[0].geometry) {
             Geometry::Box(BoxGeometry{size}) => {
                 assert_approx_eq!(size[0], 1.0f64);
                 assert_approx_eq!(size[1], 2.0f64);
@@ -153,7 +153,7 @@ mod tests {
             }
             _ => panic!("geometry error"),
         }
-        match (&robot.links[0].visual[1].geometry).into() {
+        match Geometry::from(&robot.links[0].visual[1].geometry) {
             Geometry::Mesh(MeshGeometry {
                 ref filename,
                 scale,
@@ -163,7 +163,7 @@ mod tests {
             }
             _ => panic!("geometry error"),
         }
-        match (&robot.links[0].visual[2].geometry).into() {
+        match Geometry::from(&robot.links[0].visual[2].geometry) {
             Geometry::Mesh(MeshGeometry {
                 ref filename,
                 scale,
@@ -175,7 +175,7 @@ mod tests {
         }
 
         assert_eq!(robot.links[0].collision.len(), 1);
-        match (&robot.links[0].collision[0].geometry).into() {
+        match Geometry::from(&robot.links[0].collision[0].geometry) {
             Geometry::Cylinder(CylinderGeometry { radius, length }) => {
                 assert_approx_eq!(radius, 1.0);
                 assert_approx_eq!(length, 0.5);
@@ -184,14 +184,6 @@ mod tests {
         }
 
         assert_eq!(robot.materials.len(), 1);
-        let mat = &robot.materials[0];
-        assert_eq!(mat.name, "blue");
-        assert!(mat.color.is_some());
-        let rgba = mat.color.clone().unwrap().rgba;
-        assert_approx_eq!(rgba[0], 0.0);
-        assert_approx_eq!(rgba[1], 0.0);
-        assert_approx_eq!(rgba[2], 0.8);
-        assert_approx_eq!(rgba[3], 1.0);
 
         assert_eq!(robot.joints[0].name, "shoulder_pitch");
         assert_eq!(robot.joints[0].parent.link, "shoulder1");
@@ -270,7 +262,7 @@ mod tests {
         let robot = read_from_string(s).unwrap();
         dbg!(&robot);
 
-        //check_robot(&robot);
+        check_robot(&robot);
 
         // Loopback test
         let s = write_to_string(&robot).unwrap();

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -69,7 +69,7 @@ pub fn read_file<P: AsRef<Path>>(path: P) -> Result<Robot> {
 /// ```
 
 pub fn read_from_string(string: &str) -> Result<Robot> {
-    yaserde::de::from_str(string).map_err(UrdfError::new)
+    yaserde::de::from_str(&string).map_err(UrdfError::new)
 }
 
 pub fn write_to_string(robot: &Robot) -> Result<String> {

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -84,7 +84,7 @@ pub fn write_to_string(robot: &Robot) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use crate::{read_from_string, write_to_string};
-    use crate::{BoxGeometry, CylinderGeometry, Geometry, JointType, MeshGeometry, Robot};
+    use crate::{BoxGeometry, CylinderGeometry, Geometry, MeshGeometry, Robot};
     use assert_approx_eq::assert_approx_eq;
 
     fn check_robot(robot: &Robot) {
@@ -153,7 +153,6 @@ mod tests {
         assert_eq!(robot.joints[0].name, "shoulder_pitch");
         assert_eq!(robot.joints[0].parent.link, "shoulder1");
         assert_eq!(robot.joints[0].child.link, "elbow1");
-        assert_eq!(robot.joints[0].joint_type, JointType::Revolute);
         let xyz = &robot.joints[0].axis.xyz;
         assert_approx_eq!(xyz[0], 0.0f64);
         assert_approx_eq!(xyz[1], 1.0f64);

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -165,7 +165,7 @@ mod tests {
         assert_approx_eq!(rgba[2], 1.0);
         assert_approx_eq!(rgba[3], 1.0);
 
-        match *robot.links[0].visual[0].geometry {
+        match &robot.links[0].visual[0].geometry {
             Geometry::Box { size } => {
                 assert_approx_eq!(size[0], 1.0f64);
                 assert_approx_eq!(size[1], 2.0f64);
@@ -173,7 +173,7 @@ mod tests {
             }
             _ => panic!("geometry error"),
         }
-        match *robot.links[0].visual[1].geometry {
+        match &robot.links[0].visual[1].geometry {
             Geometry::Mesh {
                 ref filename,
                 scale,
@@ -183,7 +183,7 @@ mod tests {
             }
             _ => panic!("geometry error"),
         }
-        match *robot.links[0].visual[2].geometry {
+        match &robot.links[0].visual[2].geometry {
             Geometry::Mesh {
                 ref filename,
                 scale,
@@ -195,7 +195,7 @@ mod tests {
         }
 
         assert_eq!(robot.links[0].collision.len(), 1);
-        match *robot.links[0].collision[0].geometry {
+        match &robot.links[0].collision[0].geometry {
             Geometry::Cylinder { radius, length } => {
                 assert_approx_eq!(radius, 1.0);
                 assert_approx_eq!(length, 0.5);

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -116,10 +116,10 @@ pub fn read_from_string(string: &str) -> Result<Robot> {
 }
 
 pub fn write_to_string(robot: &Robot) -> Result<String> {
-    let conf = yaserde::ser::Config {
+    let conf = yaserde::ser::Config{
         perform_indent: true,
         write_document_declaration: false,
-        indent_string: None,
+        indent_string: None
     };
     yaserde::ser::to_string_with_config(robot, &conf).map_err(UrdfError::new)
 }
@@ -127,7 +127,7 @@ pub fn write_to_string(robot: &Robot) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use crate::{read_from_string, write_to_string};
-    use crate::{BoxGeometry, CylinderGeometry, Geometry, MeshGeometry, Robot};
+    use crate::{BoxGeometry, CylinderGeometry, MeshGeometry, Geometry, Robot};
     use assert_approx_eq::assert_approx_eq;
 
     fn check_robot(robot: &Robot) {
@@ -146,7 +146,7 @@ mod tests {
         assert_approx_eq!(rpy[2], -0.3);
 
         match (&robot.links[0].visual[0].geometry).into() {
-            Geometry::Box(BoxGeometry { size }) => {
+            Geometry::Box(BoxGeometry{size}) => {
                 assert_approx_eq!(size[0], 1.0f64);
                 assert_approx_eq!(size[1], 2.0f64);
                 assert_approx_eq!(size[2], 3.0f64);

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -226,11 +226,16 @@ mod tests {
             </robot>
         "#;
         let robot = read_from_string(s).unwrap();
+        dbg!(&robot);
+
         check_robot(&robot);
 
         // Loopback test
         let s = write_to_string(&robot).unwrap();
+        println!("{}", s);
+
         let robot = read_from_string(&s).unwrap();
+        //dbg!(&robot);
         check_robot(&robot);
     }
 }

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -3,6 +3,48 @@ use crate::errors::*;
 
 use std::path::Path;
 
+/// sort <link> and <joint> to avoid the [issue](https://github.com/RReverser/serde-xml-rs/issues/5)
+fn sort_link_joint(string: &str) -> Result<String> {
+    let e: xml::Element = string.parse().map_err(UrdfError::new)?;
+    let mut links = Vec::new();
+    let mut joints = Vec::new();
+    let mut materials = Vec::new();
+    for c in &e.children {
+        if let xml::Xml::ElementNode(xml_elm) = c {
+            if xml_elm.name == "link" {
+                links.push(sort_visual_collision(xml_elm));
+            } else if xml_elm.name == "joint" {
+                joints.push(xml::Xml::ElementNode(xml_elm.clone()));
+            } else if xml_elm.name == "material" {
+                materials.push(xml::Xml::ElementNode(xml_elm.clone()));
+            }
+        }
+    }
+    let mut new_elm = e;
+    links.extend(joints);
+    links.extend(materials);
+    new_elm.children = links;
+    Ok(format!("{new_elm}"))
+}
+
+fn sort_visual_collision(elm: &xml::Element) -> xml::Xml {
+    let mut visuals = Vec::new();
+    let mut collisions = Vec::new();
+    for c in &elm.children {
+        if let xml::Xml::ElementNode(xml_elm) = c {
+            if xml_elm.name == "visual" || xml_elm.name == "inertial" {
+                visuals.push(xml::Xml::ElementNode(xml_elm.clone()));
+            } else if xml_elm.name == "collision" {
+                collisions.push(xml::Xml::ElementNode(xml_elm.clone()));
+            }
+        }
+    }
+    let mut new_elm = elm.clone();
+    visuals.extend(collisions);
+    new_elm.children = visuals;
+    xml::Xml::ElementNode(new_elm)
+}
+
 /// Read urdf file and create Robot instance
 ///
 /// # Examples
@@ -69,7 +111,8 @@ pub fn read_file<P: AsRef<Path>>(path: P) -> Result<Robot> {
 /// ```
 
 pub fn read_from_string(string: &str) -> Result<Robot> {
-    yaserde::de::from_str(&string).map_err(UrdfError::new)
+    let sorted_string = sort_link_joint(string)?;
+    yaserde::de::from_str(&sorted_string).map_err(UrdfError::new)
 }
 
 pub fn write_to_string(robot: &Robot) -> Result<String> {

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -112,22 +112,17 @@ pub fn read_file<P: AsRef<Path>>(path: P) -> Result<Robot> {
 
 pub fn read_from_string(string: &str) -> Result<Robot> {
     let sorted_string = sort_link_joint(string)?;
-    yaserde::de::from_str(&sorted_string).map_err(UrdfError::new)
+    serde_xml_rs::from_str(&sorted_string).map_err(UrdfError::new)
 }
 
 pub fn write_to_string(robot: &Robot) -> Result<String> {
-    let conf = yaserde::ser::Config{
-        perform_indent: true,
-        write_document_declaration: false,
-        indent_string: None
-    };
-    yaserde::ser::to_string_with_config(robot, &conf).map_err(UrdfError::new)
+    serde_xml_rs::to_string(robot).map_err(UrdfError::new)
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{read_from_string, write_to_string};
-    use crate::{BoxGeometry, CylinderGeometry, MeshGeometry, Geometry, Robot};
+    use crate::{Geometry, Robot};
     use assert_approx_eq::assert_approx_eq;
 
     fn check_robot(robot: &Robot) {
@@ -145,29 +140,29 @@ mod tests {
         assert_approx_eq!(rpy[1], -0.2);
         assert_approx_eq!(rpy[2], -0.3);
 
-        match Geometry::from(&robot.links[0].visual[0].geometry) {
-            Geometry::Box(BoxGeometry{size}) => {
+        match &robot.links[0].visual[0].geometry {
+            Geometry::Box { size } => {
                 assert_approx_eq!(size[0], 1.0f64);
                 assert_approx_eq!(size[1], 2.0f64);
                 assert_approx_eq!(size[2], 3.0f64);
             }
             _ => panic!("geometry error"),
         }
-        match Geometry::from(&robot.links[0].visual[1].geometry) {
-            Geometry::Mesh(MeshGeometry {
+        match &robot.links[0].visual[1].geometry {
+            Geometry::Mesh {
                 ref filename,
                 scale,
-            }) => {
+            } => {
                 assert_eq!(filename, "aa.dae");
                 assert!(scale.is_none());
             }
             _ => panic!("geometry error"),
         }
-        match Geometry::from(&robot.links[0].visual[2].geometry) {
-            Geometry::Mesh(MeshGeometry {
+        match &robot.links[0].visual[2].geometry {
+            Geometry::Mesh {
                 ref filename,
                 scale,
-            }) => {
+            } => {
                 assert_eq!(filename, "bbb.dae");
                 assert!(scale.is_some());
             }
@@ -175,8 +170,8 @@ mod tests {
         }
 
         assert_eq!(robot.links[0].collision.len(), 1);
-        match Geometry::from(&robot.links[0].collision[0].geometry) {
-            Geometry::Cylinder(CylinderGeometry { radius, length }) => {
+        match &robot.links[0].collision[0].geometry {
+            Geometry::Cylinder { radius, length } => {
                 assert_approx_eq!(radius, 1.0);
                 assert_approx_eq!(length, 0.5);
             }
@@ -186,8 +181,6 @@ mod tests {
         assert_eq!(robot.materials.len(), 1);
 
         assert_eq!(robot.joints[0].name, "shoulder_pitch");
-        assert_eq!(robot.joints[0].parent.link, "shoulder1");
-        assert_eq!(robot.joints[0].child.link, "elbow1");
         let xyz = &robot.joints[0].axis.xyz;
         assert_approx_eq!(xyz[0], 0.0f64);
         assert_approx_eq!(xyz[1], 1.0f64);
@@ -260,16 +253,13 @@ mod tests {
             </robot>
         "#;
         let robot = read_from_string(s).unwrap();
-        dbg!(&robot);
 
         check_robot(&robot);
 
         // Loopback test
         let s = write_to_string(&robot).unwrap();
-        println!("{}", s);
 
         let robot = read_from_string(&s).unwrap();
-        //dbg!(&robot);
         check_robot(&robot);
     }
 }

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -84,7 +84,7 @@ pub fn write_to_string(robot: &Robot) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use crate::{read_from_string, write_to_string};
-    use crate::{Geometry, JointType, Robot};
+    use crate::{BoxGeometry, CylinderGeometry, Geometry, JointType, MeshGeometry, Robot};
     use assert_approx_eq::assert_approx_eq;
 
     fn check_robot(robot: &Robot) {
@@ -102,29 +102,29 @@ mod tests {
         assert_approx_eq!(rpy[1], -0.2);
         assert_approx_eq!(rpy[2], -0.3);
 
-        match &robot.links[0].visual[0].geometry {
-            Geometry::Box { size } => {
+        match (&robot.links[0].visual[0].geometry).into() {
+            Geometry::Box(BoxGeometry { size }) => {
                 assert_approx_eq!(size[0], 1.0f64);
                 assert_approx_eq!(size[1], 2.0f64);
                 assert_approx_eq!(size[2], 3.0f64);
             }
             _ => panic!("geometry error"),
         }
-        match &robot.links[0].visual[1].geometry {
-            Geometry::Mesh {
+        match (&robot.links[0].visual[1].geometry).into() {
+            Geometry::Mesh(MeshGeometry {
                 ref filename,
                 scale,
-            } => {
+            }) => {
                 assert_eq!(filename, "aa.dae");
                 assert!(scale.is_none());
             }
             _ => panic!("geometry error"),
         }
-        match &robot.links[0].visual[2].geometry {
-            Geometry::Mesh {
+        match (&robot.links[0].visual[2].geometry).into() {
+            Geometry::Mesh(MeshGeometry {
                 ref filename,
                 scale,
-            } => {
+            }) => {
                 assert_eq!(filename, "bbb.dae");
                 assert!(scale.is_some());
             }
@@ -132,8 +132,8 @@ mod tests {
         }
 
         assert_eq!(robot.links[0].collision.len(), 1);
-        match &robot.links[0].collision[0].geometry {
-            Geometry::Cylinder { radius, length } => {
+        match (&robot.links[0].collision[0].geometry).into() {
+            Geometry::Cylinder(CylinderGeometry { radius, length }) => {
                 assert_approx_eq!(radius, 1.0);
                 assert_approx_eq!(length, 0.5);
             }
@@ -228,7 +228,7 @@ mod tests {
         let robot = read_from_string(s).unwrap();
         dbg!(&robot);
 
-        check_robot(&robot);
+        //check_robot(&robot);
 
         // Loopback test
         let s = write_to_string(&robot).unwrap();

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -234,7 +234,6 @@ mod tests {
 
         // Loopback test
         let s = write_to_string(&robot).unwrap();
-        assert!(!s.contains("Robot"), "{s}"); // https://github.com/openrr/urdf-rs/issues/80
         let robot = read_from_string(&s).unwrap();
         check_robot(&robot);
     }

--- a/src/funcs.rs
+++ b/src/funcs.rs
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn deserialization() {
         let s = r#"
-            <robot name="robot" xmlns="http://www.ros.org">
+            <robot name="robot">
                 <material name="blue">
                   <color rgba="0.0 0.0 0.8 1.0"/>
                 </material>


### PR DESCRIPTION
See https://github.com/openrr/urdf-rs/issues/96 for more context.

> We have switched to yaserde from serde-xml-rs in #64. However, many bugs have been introduced since then, some of which have not yet been fixed.
>
> I'm no longer happy with continuing to use this difficult-to-use crate.
> I'm considering moving away from it, at least on deserialization.

This changes:

- Reverts all yaserde related changes, excluding tests. (i.e., use serde-xml-rs for deserialization again)
- Apply https://github.com/openrr/urdf-rs/pull/98 by @luca-della-vedova (thanks for working on that!) with adjust to use quick-xml only for serialization and avoid API change.

This is considered a breaking change because yaserde trait impls are removed, but it should not contain any other breaking changes.

I'm not very happy depending on 3 XML-related crates, but I believe there is no more reliable way to fix everything that is broken (#94, #95, and probably more), introduce no new regressions (https://github.com/openrr/urdf-rs/pull/98#issuecomment-1931956647), and maintain what we wanted in #64 (i.e., serialization) than this way at this time.

Eventually I will probably select roxmltree (that we already used in our mesh-loader) for deserialization, but we don't have the bandwidth to spend on a thorough rewrite of this crate at this time.

Fixes #95
Fixes #94
Fixes https://github.com/openrr/urdf-viz/issues/256
Closes #96
Closes #98

FYI, here is a diff with 0.6.9 (last release before switching to yaserde): https://github.com/openrr/urdf-rs/compare/v0.6.9...taiki-e/revert

Co-authored-by: Luca Della Vedova <lucadv@intrinsic.ai>