### PR TITLE
Release 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urdf-rs"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Takashi Ogura <t.ogura@gmail.com>"]
 edition = "2021"
 description = "URDF parser"

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -399,6 +399,25 @@ pub struct Dynamics {
 }
 
 /// Top level struct to access urdf.
+///
+/// # Compatibility Note
+///
+/// This type and its descendant types implement `serde::Serialize` and
+/// `serde::Deserialize`. However, because XML serialization and deserialization
+/// using `serde` require embedding special markers to distinguish between
+/// attributes and elements, there is no stability guarantee as to exactly which
+/// `serde` representation these types will be serialized with.
+///
+/// In other words, serialization and deserialization without going through
+/// functions provided by this crate such as [`read_from_string`](crate::read_from_string)
+/// or [`write_to_string`](crate::write_to_string) may not work as expected at all
+/// or in the future.
+///
+/// This is intentional to remove the need to create semver-incompatible
+/// release of this crate every time an XML-related crate, which frequently
+/// creates semver-incompatible releases is updated. And it also allows
+/// improving our situation of depending on multiple XML-related crates without
+/// a change considered breaking.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename = "robot")]
 pub struct Robot {


### PR DESCRIPTION
Changes:
- #107 
- #109
- #110

---

This also add document that there is no stability guarantee as to exactly which `serde` representation Robot and descendant types will be serialized with because XML serialization and deserialization using `serde` require embedding special markers to distinguish between attributes and elements.

This means that, as long as the parsing and printing by functions provided by this crate works correctly and the trait implementation is not removed, changing markers or `serde` representation (by updates of XML-related crates, reduce dependencies on XML-related crates, etc.) is considered not a breaking change. (Note: All XML-related crate APIs have already been removed from the public API.)

(I actually don't think we are doing anything special here compared to others, I believe many of the crates that depend on this style of XML crates are virtually not guaranteeing stability on exact `serde` representation. I just clearify it in docs.)