### PR TITLE
Integrate rust xacro #1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ keywords = ["robotics", "robot", "ros", "urdf"]
 categories = ["data-structures", "parsing"]
 repository = "https://github.com/openrr/urdf-rs"
 
+[features]
+default = []
+rust-xacro = ["dep:xacro-rs"]
+
 # Note: serde is public dependency.
 [dependencies]
 quick-xml = { version = "0.39", features = ["overlapped-lists", "serialize"] }
@@ -21,6 +25,7 @@ RustyXML = "0.3.0"
 serde = { version = "1.0.118", features = ["derive"] }
 serde-xml-rs = "0.6.0"
 thiserror = "2.0.0"
+xacro-rs = { version = "0.2.2", optional = true }
 
 [dev-dependencies]
 assert_approx_eq = "1"


### PR DESCRIPTION
Hey - here's a draft PR that would integrate Rust `xacro-rs` for parsing Xacro, and would do away with any direct Python/ROS dependencies completely.

I've tested this on multiple platforms with an extensive libraries of files - it's working quite well, with urdf-viz.

For a demo, i just added a feature gate, but this could also be re-factored so it falls back to Python xacro, or prefers python - or does either based on runtime flag.

Any interest in building this in ?